### PR TITLE
Add diff jump mappings on `GinDiff`

### DIFF
--- a/denops/gin/feat/diff/commitish.ts
+++ b/denops/gin/feat/diff/commitish.ts
@@ -1,0 +1,34 @@
+export const INDEX = Symbol("INDEX");
+export const WORKTREE = Symbol("WORKTREE");
+
+export type Commitish = string | typeof INDEX | typeof WORKTREE;
+
+// git diff
+//  INDEX -> WORKTREE
+// git diff A
+//  A -> WORKTREE
+//
+// git diff --cached
+//  HEAD -> INDEX
+// git diff --cached A
+//  A -> INDEX
+//
+// git diff A..B
+//  A -> B
+// git diff A...B
+//  A...B -> B
+export function parseCommitish(
+  commitish: string,
+  cached = false,
+): [Commitish, Commitish] {
+  if (commitish.includes("...")) {
+    return [commitish, commitish.split("...")[1]];
+  } else if (commitish.includes("..")) {
+    const [a, b] = commitish.split("..", 2);
+    return [a, b];
+  } else if (cached) {
+    return [commitish, INDEX];
+  } else {
+    return [commitish || INDEX, WORKTREE];
+  }
+}

--- a/denops/gin/feat/diff/commitish_test.ts
+++ b/denops/gin/feat/diff/commitish_test.ts
@@ -1,0 +1,16 @@
+import { assertEquals } from "../../deps_test.ts";
+import { Commitish, INDEX, parseCommitish, WORKTREE } from "./commitish.ts";
+
+Deno.test("parseCommitish", () => {
+  const testcases: [[string, boolean], [Commitish, Commitish]][] = [
+    [["", false], [INDEX, WORKTREE]],
+    [["A", false], ["A", WORKTREE]],
+    [["", true], ["", INDEX]],
+    [["A", true], ["A", INDEX]],
+    [["A..B", false], ["A", "B"]],
+    [["A...B", false], ["A...B", "B"]],
+  ];
+  for (const [[commitish, cached], [lhs, rhs]] of testcases) {
+    assertEquals([lhs, rhs], parseCommitish(commitish, cached));
+  }
+});

--- a/denops/gin/feat/diff/jump.ts
+++ b/denops/gin/feat/diff/jump.ts
@@ -1,0 +1,93 @@
+const patternSpc = /^(?:@@|\-\-\-|\+\+\+) /;
+const patternRng = /^@@ \-(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@.*$/;
+const patternOld = /^\-\-\- (.*?)(?:\t.*)?$/;
+const patternNew = /^\+\+\+ (.*?)(?:\t.*)?$/;
+
+export type Jump = {
+  path: string;
+  lnum: number;
+};
+
+export function findJumpOld(
+  index: number,
+  content: string[],
+): Jump | undefined {
+  if (patternSpc.test(content[index])) {
+    // We cannot find jump for special lines
+    return undefined;
+  }
+  let path = "";
+  let lnum = -1;
+  let offset = 0;
+  for (let i = index; i >= 0; i--) {
+    const line = content[i];
+    if (lnum === -1) {
+      const m1 = line.match(patternRng);
+      if (m1) {
+        lnum = Number(m1[1]);
+        continue;
+      }
+      if (!line.startsWith("+")) {
+        offset += 1;
+      }
+    }
+    const m2 = line.match(patternOld);
+    if (m2) {
+      path = m2[1];
+      break;
+    }
+  }
+  if (lnum === -1) {
+    throw new Error(`No range pattern found in ${content}`);
+  }
+  if (path === "") {
+    throw new Error(`No old pattern found in ${content}`);
+  }
+  lnum += offset - 1;
+  return {
+    path,
+    lnum,
+  };
+}
+
+export function findJumpNew(
+  index: number,
+  content: string[],
+): Jump | undefined {
+  if (patternSpc.test(content[index])) {
+    // We cannot find jump for special lines
+    return undefined;
+  }
+  let path = "";
+  let lnum = -1;
+  let offset = 0;
+  for (let i = index; i >= 0; i--) {
+    const line = content[i];
+    if (lnum === -1) {
+      const m1 = line.match(patternRng);
+      if (m1) {
+        lnum = Number(m1[2]);
+        continue;
+      }
+      if (!line.startsWith("-")) {
+        offset += 1;
+      }
+    }
+    const m2 = line.match(patternNew);
+    if (m2) {
+      path = m2[1];
+      break;
+    }
+  }
+  if (lnum === -1) {
+    throw new Error(`No range pattern found in ${content}`);
+  }
+  if (path === "") {
+    throw new Error(`No new pattern found in ${content}`);
+  }
+  lnum += Math.max(offset - 1, 0);
+  return {
+    path,
+    lnum,
+  };
+}

--- a/denops/gin/feat/diff/jump_test.diff
+++ b/denops/gin/feat/diff/jump_test.diff
@@ -1,0 +1,19 @@
+--- a/path/to/lao	2002-02-21 23:30:39.942229878 -0800
++++ b/path/to/tzu	2002-02-21 23:30:50.442260588 -0800
+@@ -1,7 +1,6 @@
+-The Way that can be told of is not the eternal Way;
+-The name that can be named is not the eternal name.
+ The Nameless is the origin of Heaven and Earth;
+-The Named is the mother of all things.
++The named is the mother of all things.
++
+ Therefore let there always be non-being,
+   so we may see their subtlety,
+ And let there always be being,
+@@ -9,3 +8,6 @@
+ The two are the same,
+ But after they are produced,
+   they have different names.
++They both may be called deep and profound.
++Deeper and more profound,
++The door of all subtleties!

--- a/denops/gin/feat/diff/jump_test.ts
+++ b/denops/gin/feat/diff/jump_test.ts
@@ -1,0 +1,60 @@
+import { assertEquals } from "../../deps_test.ts";
+import { findJumpNew, findJumpOld, Jump } from "./jump.ts";
+
+const example = (await Deno.readTextFile(
+  new URL("./jump_test.diff", import.meta.url),
+)).split("\n");
+
+Deno.test("findOldJump", () => {
+  const testcases: [number, Jump | undefined][] = [
+    [0, undefined],
+    [1, undefined],
+    [2, undefined],
+    [3, { path: "a/path/to/lao", lnum: 1 }],
+    [4, { path: "a/path/to/lao", lnum: 2 }],
+    [5, { path: "a/path/to/lao", lnum: 3 }],
+    [6, { path: "a/path/to/lao", lnum: 4 }],
+    [7, { path: "a/path/to/lao", lnum: 4 }],
+    [8, { path: "a/path/to/lao", lnum: 4 }],
+    [9, { path: "a/path/to/lao", lnum: 5 }],
+    [10, { path: "a/path/to/lao", lnum: 6 }],
+    [11, { path: "a/path/to/lao", lnum: 7 }],
+    [12, undefined],
+    [13, { path: "a/path/to/lao", lnum: 9 }],
+    [14, { path: "a/path/to/lao", lnum: 10 }],
+    [15, { path: "a/path/to/lao", lnum: 11 }],
+    [16, { path: "a/path/to/lao", lnum: 11 }],
+    [17, { path: "a/path/to/lao", lnum: 11 }],
+    [18, { path: "a/path/to/lao", lnum: 11 }],
+  ];
+  for (const [idx, exp] of testcases) {
+    assertEquals(exp, findJumpOld(idx, example));
+  }
+});
+
+Deno.test("findNewJump", () => {
+  const testcases: [number, Jump | undefined][] = [
+    [0, undefined],
+    [1, undefined],
+    [2, undefined],
+    [3, { path: "b/path/to/tzu", lnum: 1 }],
+    [4, { path: "b/path/to/tzu", lnum: 1 }],
+    [5, { path: "b/path/to/tzu", lnum: 1 }],
+    [6, { path: "b/path/to/tzu", lnum: 1 }],
+    [7, { path: "b/path/to/tzu", lnum: 2 }],
+    [8, { path: "b/path/to/tzu", lnum: 3 }],
+    [9, { path: "b/path/to/tzu", lnum: 4 }],
+    [10, { path: "b/path/to/tzu", lnum: 5 }],
+    [11, { path: "b/path/to/tzu", lnum: 6 }],
+    [12, undefined],
+    [13, { path: "b/path/to/tzu", lnum: 8 }],
+    [14, { path: "b/path/to/tzu", lnum: 9 }],
+    [15, { path: "b/path/to/tzu", lnum: 10 }],
+    [16, { path: "b/path/to/tzu", lnum: 11 }],
+    [17, { path: "b/path/to/tzu", lnum: 12 }],
+    [18, { path: "b/path/to/tzu", lnum: 13 }],
+  ];
+  for (const [idx, exp] of testcases) {
+    assertEquals(exp, findJumpNew(idx, example));
+  }
+});

--- a/denops/gin/feat/diff/main.ts
+++ b/denops/gin/feat/diff/main.ts
@@ -1,5 +1,5 @@
 import { Denops, helper, unknownutil } from "../../deps.ts";
-import { command, read } from "./command.ts";
+import { command, jumpNew, jumpOld, read } from "./command.ts";
 
 export function main(denops: Denops): void {
   denops.dispatcher = {
@@ -9,5 +9,7 @@ export function main(denops: Denops): void {
       return helper.friendlyCall(denops, () => command(denops, args));
     },
     "diff:read": () => read(denops),
+    "diff:jump:new": () => jumpNew(denops),
+    "diff:jump:old": () => jumpOld(denops),
   };
 }

--- a/doc/gin.txt
+++ b/doc/gin.txt
@@ -165,6 +165,17 @@ COMMANDS					*gin-commands*
 	If no {worktree} is specified, gin will find the one from the current
 	working directory.
 
+	Users can use the following mappings in each buffers or disable
+	default mappings by |g:gin_diff_disable_default_mappings|.
+
+	*<Plug>(gin-diffjump-old)*	Jump to the corresponding line of the
+					comparison source.
+					Assigned to "g<CR>" in default.
+
+	*<Plug>(gin-diffjump-new)*	Jump to the corresponding line of the
+					comparison.
+					Assigned to "<CR>" in default.
+
 	The following {flags} are available:
 
 	--cached
@@ -265,6 +276,11 @@ VARIABLES					*gin-variables*
 	|:GinChaperon| command.
 
 	Default: 10
+
+*g:gin_diff_disable_default_mappings*
+	Disable default mappings on buffers shown by `:GinDiff`.
+
+	Default: 0
 
 *g:gin_patch_disable_default_mappings*
 	Disable default mappings on buffers shown by `:GinPatch`.


### PR DESCRIPTION
Now user can use `<CR>` or `g<CR>` to jump to the corresponding line of the comparison source and destination.