### PR TITLE
Use `++` prefix instead for Gin specific options in `GinChaperon` and `GinPatch`

### DIFF
--- a/autoload/gin/internal/feat/status/action.vim
+++ b/autoload/gin/internal/feat/status/action.vim
@@ -2,22 +2,18 @@ function! gin#internal#feat#status#action#register() abort
   call gin#internal#feat#status#action#edit#register()
   call gin#internal#feat#status#action#diff#register()
 
-  noremap <buffer> <Plug>(gin-action-chaperon:supplements)
+  noremap <buffer> <Plug>(gin-action-chaperon)
         \ <Cmd>call gin#action#fn({ xs -> <SID>chaperon('', xs) })<CR>
-  noremap <buffer> <Plug>(gin-action-chaperon:supplements:theirs)
-        \ <Cmd>call gin#action#fn({ xs -> <SID>chaperon('--without-ours', xs) })<CR>
-  noremap <buffer> <Plug>(gin-action-chaperon:supplements:ours)
-        \ <Cmd>call gin#action#fn({ xs -> <SID>chaperon('--without-theirs', xs) })<CR>
-  noremap <buffer> <Plug>(gin-action-chaperon:nosupplements)
-        \ <Cmd>call gin#action#fn({ xs -> <SID>chaperon('--without-supplements', xs) })<CR>
-  noremap <buffer> <Plug>(gin-action-chaperon:nosupplements:theirs)
-        \ <Cmd>call gin#action#fn({ xs -> <SID>chaperon('--without-supplements --without-ours', xs) })<CR>
-  noremap <buffer> <Plug>(gin-action-chaperon:nosupplements:ours)
-        \ <Cmd>call gin#action#fn({ xs -> <SID>chaperon('--without-supplements --without-theirs', xs) })<CR>
-  map <buffer> <Plug>(gin-action-chaperon) <Plug>(gin-action-chaperon:supplements)
-  map <buffer> <Plug>(gin-action-chaperon:theirs) <Plug>(gin-action-chaperon:supplements:theirs)
-  map <buffer> <Plug>(gin-action-chaperon:ours) <Plug>(gin-action-chaperon:supplements:ours)
-
+  noremap <buffer> <Plug>(gin-action-chaperon:theirs)
+        \ <Cmd>call gin#action#fn({ xs -> <SID>chaperon('++no-ours', xs) })<CR>
+  noremap <buffer> <Plug>(gin-action-chaperon:ours)
+        \ <Cmd>call gin#action#fn({ xs -> <SID>chaperon('++no-theirs', xs) })<CR>
+  noremap <buffer> <Plug>(gin-action-chaperon:plain)
+        \ <Cmd>call gin#action#fn({ xs -> <SID>chaperon('++plain', xs) })<CR>
+  noremap <buffer> <Plug>(gin-action-chaperon:plain:theirs)
+        \ <Cmd>call gin#action#fn({ xs -> <SID>chaperon('++plain ++no-ours', xs) })<CR>
+  noremap <buffer> <Plug>(gin-action-chaperon:plain:ours)
+        \ <Cmd>call gin#action#fn({ xs -> <SID>chaperon('++plain ++no-theirs', xs) })<CR>
 
   noremap <buffer> <Plug>(gin-action-patch)
         \ <Cmd>call gin#action#fn({ xs -> <SID>patch('', xs) })<CR>

--- a/autoload/gin/internal/feat/status/action.vim
+++ b/autoload/gin/internal/feat/status/action.vim
@@ -18,9 +18,9 @@ function! gin#internal#feat#status#action#register() abort
   noremap <buffer> <Plug>(gin-action-patch)
         \ <Cmd>call gin#action#fn({ xs -> <SID>patch('', xs) })<CR>
   noremap <buffer> <Plug>(gin-action-patch:head)
-        \ <Cmd>call gin#action#fn({ xs -> <SID>patch('--without-worktree', xs) })<CR>
+        \ <Cmd>call gin#action#fn({ xs -> <SID>patch('++no-worktree', xs) })<CR>
   noremap <buffer> <Plug>(gin-action-patch:worktree)
-        \ <Cmd>call gin#action#fn({ xs -> <SID>patch('--without-head', xs) })<CR>
+        \ <Cmd>call gin#action#fn({ xs -> <SID>patch('++no-head', xs) })<CR>
 
   noremap <buffer> <Plug>(gin-action-add)
         \ <Cmd>call gin#action#fn({ xs -> <SID>add('', xs) })<CR>

--- a/denops/gin/feat/patch/command.ts
+++ b/denops/gin/feat/patch/command.ts
@@ -3,7 +3,6 @@ import {
   builtinOpts,
   formatOpts,
   parse,
-  validateFlags,
   validateOpts,
 } from "../../util/args.ts";
 import * as buffer from "../../util/buffer.ts";
@@ -15,15 +14,15 @@ export async function command(
   denops: Denops,
   args: string[],
 ): Promise<void> {
-  const [opts, flags, residue] = parse(await normCmdArgs(denops, args));
+  const [opts, _, residue] = parse(await normCmdArgs(denops, args));
   validateOpts(opts, [
     "worktree",
+    "no-head",
+    "no-worktree",
     ...builtinOpts,
   ]);
-  validateFlags(flags, [
-    "without-head",
-    "without-worktree",
-  ]);
+  const noHead = "no-head" in opts;
+  const noWorktree = "no-worktree" in opts;
   const [abspath] = parseResidue(residue);
   const worktree = await getWorktreeFromOpts(denops, opts);
   const leading = formatOpts(opts, builtinOpts);
@@ -36,7 +35,7 @@ export async function command(
   unknownutil.assertBoolean(disableDefaultMappings);
 
   let bufnrHead = -1;
-  if (!flags["without-head"]) {
+  if (!noHead) {
     await editCommand(denops, [
       ...leading,
       `++worktree=${worktree}`,
@@ -56,7 +55,7 @@ export async function command(
   const bufnrIndex = await fn.bufnr(denops);
 
   let bufnrWorktree = -1;
-  if (!flags["without-worktree"]) {
+  if (!noWorktree) {
     await denops.cmd("botright vsplit");
     await editCommand(denops, [
       ...leading,

--- a/doc/gin.txt
+++ b/doc/gin.txt
@@ -129,16 +129,15 @@ COMMANDS					*gin-commands*
 	to see mappings or disable by |g:gin_branch_disable_default_mappings|.
 
 								*:GinChaperon*
-:GinChaperon [++{option}...] [--without-supplements] {path}
-:GinChaperon [++{option}...] [--without-supplements] --without-theirs {path}
-:GinChaperon [++{option}...] [--without-supplements] --without-ours {path}
+:GinChaperon [++{option}...] [++plain] {path}
+:GinChaperon [++{option}...] [++plain] ++no-theirs {path}
+:GinChaperon [++{option}...] [++plain] ++no-ours {path}
 	Open three main buffers (THEIRS, WORKTREE, and OURS) and three
 	supplemental buffers to solve conflicts on {path}.
 	See |gin-command-options| for available {option}s.
-	If --without-theirs is specified, it does not open a THEIRS buffer.
-	If --without-ours is specified, it does not open a OURS buffer.
-	If --without-supplements is specified, it does not open supplemental
-	buffers.
+	If ++plain is specified, it does not open supplemental buffers.
+	If ++no-theirs is specified, it does not open a THEIRS buffer.
+	If ++no-ours is specified, it does not open a OURS buffer.
 
 	Use |g:gin_chaperon_supplement_height| to regulate the height of
 	supplemental buffers.
@@ -216,14 +215,13 @@ COMMANDS					*gin-commands*
 
 								*:GinPatch*
 :GinPatch [++{option}...] {path}
-:GinPatch [++{option}...] --without-head {path}
-:GinPatch [++{option}...] --without-worktree {path}
+:GinPatch [++{option}...] ++no-head {path}
+:GinPatch [++{option}...] ++no-worktree {path}
 	Open three buffers (HEAD, INDEX, and WORKTREE) to patch changes of
 	{path}.
 	See |gin-command-options| for available {option}s.
-	If --without-head is specified, it does not open a HEAD buffer.
-	If --without-worktree is specified, it does not open a WORKTREE
-	buffer.
+	If ++no-head is specified, it does not open a HEAD buffer.
+	If ++no-worktree is specified, it does not open a WORKTREE buffer.
 
 	Users can use the following mappings in each buffers or disable
 	default mappings by |g:gin_patch_disable_default_mappings|.
@@ -485,19 +483,13 @@ ACTIONS						*gin-actions*
 *<Plug>(gin-action-chaperon)*
 *<Plug>(gin-action-chaperon:theirs)*
 *<Plug>(gin-action-chaperon:ours)*
-*<Plug>(gin-action-chaperon:supplements)*
-*<Plug>(gin-action-chaperon:supplements:theirs)*
-*<Plug>(gin-action-chaperon:supplements:ours)*
-*<Plug>(gin-action-chaperon:nosupplements)*
-*<Plug>(gin-action-chaperon:nosupplements:theirs)*
-*<Plug>(gin-action-chaperon:nosupplements:ours)*
+*<Plug>(gin-action-chaperon:plain)*
+*<Plug>(gin-action-chaperon:plain:theirs)*
+*<Plug>(gin-action-chaperon:plain:ours)*
 	Call |:GinChaperon| on active action candidates to solve conflicts.
 	If ":theirs" or ":ours" variant is used, it call the command with
-	"--without-ours" or "--without-theirs" respectively.
-	If ":nosupplements" variant is used, it call the command with
-	"--without-supplements".
-	Variants without ":supplements" or ":nosupplements" are aliased to
-	":supplements" variants.
+	"++no-ours" or "++no-theirs" respectively.
+	If ":plain" variant is used, it call the command with "++plain".
 
 *<Plug>(gin-action-patch)*
 *<Plug>(gin-action-patch:head)*
@@ -505,7 +497,7 @@ ACTIONS						*gin-actions*
 	Call |:GinPatch| on active action candidates to stage changes
 	partially.
 	If ":head" or ":worktree" variant is used, it call the command with
-	"--without-worktree" or "--without-head" respectively.
+	"++no-worktree" or "++no-head" respectively.
 
 *<Plug>(gin-action-add)*
 *<Plug>(gin-action-add:intent-to-add)*


### PR DESCRIPTION
##### `GinChaperon`
- --without-ours to ++no-ours
- --without-theirs to ++no-theirs
- --without-supplements to ++plain

##### `GinPatch`
- --without-head -> ++no-head
- --without-worktree -> ++no-worktree

It fixes #37 as well.