### PR TITLE
Add `statusline` and `tabline` component functions

### DIFF
--- a/autoload/gin/component/branch.vim
+++ b/autoload/gin/component/branch.vim
@@ -1,0 +1,17 @@
+function! gin#component#branch#ascii(...) abort
+  try
+    let cwd = a:0 ? a:1 : ''
+    return denops#request('gin', 'component:branch:ascii', [cwd])
+  catch
+    return ""
+  endtry
+endfunction
+
+function! gin#component#branch#unicode(...) abort
+  try
+    let cwd = a:0 ? a:1 : ''
+    return denops#request('gin', 'component:branch:unicode', [cwd])
+  catch
+    return ""
+  endtry
+endfunction

--- a/autoload/gin/component/traffic.vim
+++ b/autoload/gin/component/traffic.vim
@@ -1,0 +1,17 @@
+function! gin#component#traffic#ascii(...) abort
+  try
+    let cwd = a:0 ? a:1 : ''
+    return denops#request('gin', 'component:traffic:ascii', [cwd])
+  catch
+    return ""
+  endtry
+endfunction
+
+function! gin#component#traffic#unicode(...) abort
+  try
+    let cwd = a:0 ? a:1 : ''
+    return denops#request('gin', 'component:traffic:unicode', [cwd])
+  catch
+    return ""
+  endtry
+endfunction

--- a/autoload/gin/component/worktree.vim
+++ b/autoload/gin/component/worktree.vim
@@ -1,0 +1,17 @@
+function! gin#component#worktree#full(...) abort
+  try
+    let cwd = a:0 ? a:1 : ''
+    return denops#request('gin', 'component:worktree:full', [cwd])
+  catch
+    return ""
+  endtry
+endfunction
+
+function! gin#component#worktree#name(...) abort
+  try
+    let cwd = a:0 ? a:1 : ''
+    return denops#request('gin', 'component:worktree:name', [cwd])
+  catch
+    return ""
+  endtry
+endfunction

--- a/denops/gin/component/branch.ts
+++ b/denops/gin/component/branch.ts
@@ -1,0 +1,60 @@
+import { Cache, Denops, unknownutil } from "../deps.ts";
+import { decodeUtf8 } from "../util/text.ts";
+import { getWorktree } from "../util/worktree.ts";
+import { execute } from "../git/process.ts";
+
+type Data = [string, string];
+
+const cache = new Cache<string, Data>(100);
+
+async function getData(
+  denops: Denops,
+  worktree: string,
+): Promise<Data> {
+  if (cache.has("data")) {
+    return cache.get("data");
+  }
+  const cwd = worktree || await getWorktree(denops);
+  const result = await getBranches(cwd);
+  cache.set("data", result);
+  return result;
+}
+
+async function getBranches(
+  cwd: string,
+): Promise<Data> {
+  const stdout = await execute([
+    "rev-parse",
+    "--abbrev-ref",
+    "--symbolic-full-name",
+    "HEAD",
+    "@{u}",
+  ], {
+    noOptionalLocks: true,
+    cwd,
+  });
+  const [branch, upstream] = decodeUtf8(stdout).split("\n");
+  return [branch, upstream];
+}
+
+export function main(denops: Denops): void {
+  denops.dispatcher = {
+    ...denops.dispatcher,
+    "component:branch:ascii": async (worktree) => {
+      unknownutil.assertString(worktree);
+      const [branch, upstream] = await getData(denops, worktree);
+      if (branch && upstream) {
+        return `${branch} -> ${upstream}`;
+      }
+      return branch;
+    },
+    "component:branch:unicode": async (worktree) => {
+      unknownutil.assertString(worktree);
+      const [branch, upstream] = await getData(denops, worktree);
+      if (branch && upstream) {
+        return `${branch} → ${upstream}`;
+      }
+      return branch;
+    },
+  };
+}

--- a/denops/gin/component/traffic.ts
+++ b/denops/gin/component/traffic.ts
@@ -1,0 +1,78 @@
+import { Cache, Denops, unknownutil } from "../deps.ts";
+import { decodeUtf8 } from "../util/text.ts";
+import { getWorktree } from "../util/worktree.ts";
+import { execute } from "../git/process.ts";
+
+type Data = [number, number];
+
+const cache = new Cache<string, Data>(100);
+
+async function getData(
+  denops: Denops,
+  worktree: string,
+): Promise<Data> {
+  if (cache.has("data")) {
+    return cache.get("data");
+  }
+  const cwd = worktree || await getWorktree(denops);
+  const result = await Promise.all([
+    getAhead(cwd),
+    getBehind(cwd),
+  ]);
+  cache.set("data", result);
+  return result;
+}
+
+async function getAhead(cwd: string): Promise<number> {
+  const stdout = await execute([
+    "rev-list",
+    "--count",
+    "@{u}..HEAD",
+  ], {
+    noOptionalLocks: true,
+    cwd,
+  });
+  return Number(decodeUtf8(stdout));
+}
+
+async function getBehind(cwd: string): Promise<number> {
+  const stdout = await execute([
+    "rev-list",
+    "--count",
+    "HEAD..@{u}",
+  ], {
+    noOptionalLocks: true,
+    cwd,
+  });
+  return Number(decodeUtf8(stdout));
+}
+
+export function main(denops: Denops): void {
+  denops.dispatcher = {
+    ...denops.dispatcher,
+    "component:traffic:ascii": async (worktree) => {
+      unknownutil.assertString(worktree);
+      const [ahead, behind] = await getData(denops, worktree);
+      let component = "";
+      if (ahead) {
+        component += `^${ahead}`;
+      }
+      if (behind) {
+        component += `v${behind}`;
+      }
+      return component;
+    },
+    "component:traffic:unicode": async (worktree) => {
+      unknownutil.assertString(worktree);
+      const [ahead, behind] = await getData(denops, worktree);
+      let component = "";
+      if (ahead) {
+        component += `↑${ahead}`;
+      }
+      if (behind) {
+        component += `↓${behind}`;
+      }
+      return component;
+    },
+  };
+}

--- a/denops/gin/component/worktree.ts
+++ b/denops/gin/component/worktree.ts
@@ -1,0 +1,36 @@
+import { Cache, Denops, path, unknownutil } from "../deps.ts";
+import { getWorktree } from "../util/worktree.ts";
+import { find } from "../git/finder.ts";
+
+type Data = string;
+
+const cache = new Cache<string, Data>(100);
+
+async function getData(
+  denops: Denops,
+  worktree: string,
+): Promise<Data> {
+  if (cache.has("data")) {
+    return cache.get("data");
+  }
+  const cwd = worktree || await getWorktree(denops);
+  const result = await find(cwd);
+  cache.set("data", result);
+  return result;
+}
+
+export function main(denops: Denops): void {
+  denops.dispatcher = {
+    ...denops.dispatcher,
+    "component:worktree:full": async (worktree) => {
+      unknownutil.assertString(worktree);
+      const fullpath = await getData(denops, worktree);
+      return fullpath;
+    },
+    "component:worktree:name": async (worktree) => {
+      unknownutil.assertString(worktree);
+      const fullpath = await getData(denops, worktree);
+      return path.basename(fullpath);
+    },
+  };
+}

--- a/denops/gin/main.ts
+++ b/denops/gin/main.ts
@@ -12,6 +12,10 @@ import { main as mainEdit } from "./feat/edit/main.ts";
 import { main as mainPatch } from "./feat/patch/main.ts";
 import { main as mainStatus } from "./feat/status/main.ts";
 
+import { main as mainComponentBranch } from "./component/branch.ts";
+import { main as mainComponentTraffic } from "./component/traffic.ts";
+import { main as mainComponentWorktree } from "./component/worktree.ts";
+
 export function main(denops: Denops): void {
   mainAction(denops);
   mainBare(denops);
@@ -24,4 +28,8 @@ export function main(denops: Denops): void {
   mainEdit(denops);
   mainPatch(denops);
   mainStatus(denops);
+
+  mainComponentBranch(denops);
+  mainComponentTraffic(denops);
+  mainComponentWorktree(denops);
 }

--- a/denops/gin/util/worktree.ts
+++ b/denops/gin/util/worktree.ts
@@ -13,7 +13,7 @@ import { expand } from "../util/cmd.ts";
 import { Opts } from "../util/args.ts";
 import { find } from "../git/finder.ts";
 
-async function getWorktree(denops: Denops): Promise<string> {
+export async function getWorktree(denops: Denops): Promise<string> {
   const [cwd, filename, verbose] = await batch.gather(
     denops,
     async (denops) => {

--- a/doc/gin.txt
+++ b/doc/gin.txt
@@ -16,6 +16,7 @@ INTERFACE			|gin-interface|
   COMMANDS			  |gin-commands|
   VARIABLES			  |gin-variables|
   FUNCTIONS			  |gin-functions|
+  COMPONENTS			  |gin-components|
   MAPPINGS			  |gin-mappings|
   ACTIONS			  |gin-actions|
 
@@ -346,6 +347,47 @@ gin#action#list_actions()
 	       				*gin#action#gather_candidates()*
 gin#action#gather_candidates({range})
 	Gather and return candidates of the current buffer in {range}.
+
+-----------------------------------------------------------------------------
+COMPONENTS					*gin-components*
+
+Components are |Function| that return a string for |statusline| and |tabline|.
+The function will never throw errors and fail silently.
+Note that the result of function is cached shortly to keep performance.
+If no {worktree} is specified or an empty string, gin tries to find one like
+++worktree option explained in |gin-command-options|.
+>
+	set statusline+=\ %{gin#component#worktree#name()}
+	set statusline+=\ (%{gin#component#branch#ascii()})
+	set statusline+=\ [%{gin#component#traffic#ascii()}]
+<
+Because |statusline| and/or |tabline| is not rendered on |BufEnter|, the
+following configuration is recommended for fast update.
+>
+	augroup gin_component_fast_update
+	  autocmd!
+	  autocmd BufEnter * ++nested redrawstatusline
+	  " Or if you prefer tabline, use below
+	  "autocmd BufEnter * ++nested redrawtabline
+	augroup END
+<
+					*gin#component#branch#ascii()*
+					*gin#component#branch#unicode()*
+gin#component#branch#ascii([{worktree}])
+gin#component#branch#unicode([{worktree}])
+	Return an indicator string of a current and upstream branches.
+
+					*gin#component#traffic#ascii()*
+					*gin#component#traffic#unicode()*
+gin#component#traffic#ascii([{worktree}])
+gin#component#traffic#unicode([{worktree}])
+	Return an indicator string of the number of ahead and behind commits.
+
+					*gin#component#worktree#full()*
+					*gin#component#worktree#name()*
+gin#component#worktree#full([{worktree}])
+gin#component#worktree#name([{worktree}])
+	Return an indicator string of the current worktree.
 
 -----------------------------------------------------------------------------
 MAPPINGS					*gin-mappings*


### PR DESCRIPTION

![CleanShot 2022-03-31 at 03 25 24](https://user-images.githubusercontent.com/546312/160905269-c83ebe27-25eb-4f04-a432-fb43c86195e1.png)


Now following component functions are available

- `gin#component#branch#ascii()`
- `gin#component#branch#unicode()`
- `gin#component#traffic#ascii()`
- `gin#component#traffic#unicode()`
- `gin#component#worktree#full()`
- `gin#component#worktree#name()`

Use those like

```vim
set statusline+=\ %{gin#component#worktree#name()}
set statusline+=\ (%{gin#component#branch#unicode()})
set statusline+=\ [%{gin#component#traffic#unicode()}]
```

Or with [lightline.vim](https://github.com/itchyny/lightline.vim)

```vim
let g:lightline = {
	\ 'colorscheme': 'wombat',
	\ 'active': {
	\   'left': [['mode', 'paste'], ['gitbranch']],
	\ },
	\ 'component_function': {
	\   'gitbranch': 'gin#component#branch#unicode',
	\ },
	\}
```