### PR TITLE
:bug: Fix error when call component before plugin started

### DIFF
--- a/autoload/gin/internal/component.vim
+++ b/autoload/gin/internal/component.vim
@@ -19,6 +19,9 @@ function! gin#internal#component#get(component) abort
 endfunction
 
 function! gin#internal#component#update(component) abort
+  if !denops#plugin#is_loaded('gin')
+    return
+  endif
   let previous = get(s:cache, a:component, '')
   call denops#request_async(
         \ 'gin',


### PR DESCRIPTION
Occurs error when call component function at vim starting.(e.g. set to lightline component function)
Therefore, delay function call to plugin start in that case.