### PR TITLE
:bug: Fix can't update component at DenopsPluginPost

### DIFF
--- a/autoload/gin/internal/component.vim
+++ b/autoload/gin/internal/component.vim
@@ -10,7 +10,8 @@ function! gin#internal#component#init(component) abort
     autocmd!
     execute printf('autocmd BufEnter * call gin#internal#component#update("%s")', a:component)
     execute printf('autocmd User GinCommandPost call gin#internal#component#update("%s")', a:component)
-    execute printf('autocmd User DenopsPluginPost:gin call gin#internal#component#update("%s")', a:component)
+    " Delay call a bit because `denps#plugin#is_loaded()` returns zero at point of `DenopsPluginPost`.
+    execute printf('autocmd User DenopsPluginPost:gin call timer_start(0, { -> gin#internal#component#update("%s")})', a:component)
   augroup END
 endfunction
 


### PR DESCRIPTION
`denps#plugin#is_loaded()` returns zero at point of `DenopsPluginPost`.
Therefore delay a bit using timer.