### PR TITLE
:bug: Fix error when open branch that commit message contains `vim:`

### DIFF
--- a/denops/gin/core/buffer/edit.ts
+++ b/denops/gin/core/buffer/edit.ts
@@ -105,6 +105,7 @@ export async function exec(
       await option.buftype.setLocal(denops, "nofile");
       await option.swapfile.setLocal(denops, false);
       await option.modifiable.setLocal(denops, false);
+      await option.modeline.setLocal(denops, false);
     });
   });
 }


### PR DESCRIPTION
When I run `:GinBranch` then occurs error because commit message contains `vim:`.

```
[gin]: Failed to call 'call' with ["DenopsStdBufferOpen_lc73lanb8ophz0o2ixx","","edit","","ginbranch:///Users/skanehira/dev/github.com/skanehira/dotfiles;#$"]: Error: Failed to call 'nvim_call_function' with ["D
enopsStdBufferOpen_lc73lanb8ophz0o2ixx",["","edit","","ginbranch:///Users/skanehira/dev/github.com/skanehira/dotfiles;#$"]]: [0,"Vim(edit):E518: Unknown option: add "]
    at Session.call (https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:207:13)
    at async Session.call (file:///Users/skanehira/.local/share/nvim/site/pack/packer/start/denops.vim/denops/@denops-private/service.ts:170:14)
    at async Session.dispatch (https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:99:12)
    at async https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:108:18
    at async Session.handleRequest (https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:104:29)
```