### PR TITLE
:bug: Fix find worktree fails from `GinLog`

### DIFF
--- a/denops/gin/global.ts
+++ b/denops/gin/global.ts
@@ -3,6 +3,7 @@ export const GIN_BUFFER_PROTOCOLS = [
   "ginbranch",
   "gindiff",
   "ginedit",
+  "ginlog",
   "ginstatus",
 ];
 export const GIN_FILE_BUFFER_PROTOCOLS = ["gindiff", "ginedit"];


### PR DESCRIPTION
This PR fixes problem explained below.

# Problem

In `GinLog` buffer, always used cwd as worktree at action.

# Expect

Wants to using worktree of current buffer.