### PR TITLE
👍 Improve file like buffers

### DIFF
--- a/denops/gin/command/diff/command.ts
+++ b/denops/gin/command/diff/command.ts
@@ -44,7 +44,7 @@ export async function exec(
       processor: unnullish(options.processor, (v) => v.join(" ")),
       commitish: options.commitish,
     },
-    fragment: unnullish(paths, (v) => `${JSON.stringify(v)}$`),
+    fragment: unnullish(paths, JSON.stringify),
   });
   return await buffer.open(denops, bufname, {
     opener: options.opener,

--- a/denops/gin/command/diff/edit.ts
+++ b/denops/gin/command/diff/edit.ts
@@ -31,7 +31,7 @@ export async function edit(
     processor: unnullish(params?.processor, (v) => ensureString(v).split(" ")),
     worktree: expr,
     commitish: unnullish(params?.commitish, ensureString),
-    paths: unnullish(fragment, (v) => JSON.parse(v.replace(/\$$/, ""))),
+    paths: unnullish(fragment, JSON.parse),
     flags: {
       ...params,
       processor: undefined,

--- a/denops/gin/command/diff/read.ts
+++ b/denops/gin/command/diff/read.ts
@@ -27,7 +27,7 @@ export async function read(
     processor: unnullish(opts.processor, (v) => v.split(" ")),
     worktree: expr,
     commitish: unnullish(params?.commitish, ensureString),
-    paths: unnullish(fragment, (v) => JSON.parse(v.replace(/\$$/, ""))),
+    paths: unnullish(fragment, JSON.parse),
     flags: {
       ...params,
       commitish: undefined,

--- a/denops/gin/command/log/command.ts
+++ b/denops/gin/command/log/command.ts
@@ -1,4 +1,5 @@
 import type { Denops } from "https://deno.land/x/denops_std@v4.1.0/mod.ts";
+import * as path from "https://deno.land/std@0.180.0/path/mod.ts";
 import { unnullish } from "https://deno.land/x/unnullish@v1.0.0/mod.ts";
 import * as buffer from "https://deno.land/x/denops_std@v4.1.0/buffer/mod.ts";
 import * as option from "https://deno.land/x/denops_std@v4.1.0/option/mod.ts";
@@ -10,6 +11,7 @@ import { findWorktreeFromDenops } from "../../git/worktree.ts";
 
 export type ExecOptions = {
   worktree?: string;
+  commitish?: string;
   paths?: string[];
   flags?: Flags;
   opener?: string;
@@ -29,13 +31,18 @@ export async function exec(
     verbose: !!verbose,
   });
 
+  const paths = options.paths?.map((p) =>
+    path.isAbsolute(p) ? path.relative(worktree, p) : p
+  );
+
   const bufname = formatBufname({
     scheme: "ginlog",
     expr: worktree,
     params: {
       ...options.flags ?? {},
+      commitish: options.commitish,
     },
-    fragment: unnullish(options.paths, (v) => `${JSON.stringify(v)}$`),
+    fragment: unnullish(paths, JSON.stringify),
   });
   return await buffer.open(denops, bufname, {
     opener: options.opener,

--- a/denops/gin/command/log/read.ts
+++ b/denops/gin/command/log/read.ts
@@ -1,0 +1,66 @@
+import type { Denops } from "https://deno.land/x/denops_std@v4.1.0/mod.ts";
+import { unnullish } from "https://deno.land/x/unnullish@v1.0.0/mod.ts";
+import { ensureString } from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
+import * as vars from "https://deno.land/x/denops_std@v4.1.0/variable/mod.ts";
+import {
+  parse as parseBufname,
+} from "https://deno.land/x/denops_std@v4.1.0/bufname/mod.ts";
+import {
+  builtinOpts,
+  Flags,
+  formatFlags,
+  parseOpts,
+  validateOpts,
+} from "https://deno.land/x/denops_std@v4.1.0/argument/mod.ts";
+import { exec as execBuffer } from "../../command/buffer/read.ts";
+
+export async function read(
+  denops: Denops,
+  bufnr: number,
+  bufname: string,
+): Promise<void> {
+  const cmdarg = await vars.v.get(denops, "cmdarg") as string;
+  const [opts, _] = parseOpts(cmdarg.split(" "));
+  validateOpts(opts, builtinOpts);
+  const { expr, params, fragment } = parseBufname(bufname);
+  await exec(denops, bufnr, {
+    worktree: expr,
+    commitish: unnullish(params?.commitish, ensureString),
+    paths: unnullish(fragment, JSON.parse),
+    flags: {
+      ...params,
+      commitish: undefined,
+    },
+    encoding: opts.enc ?? opts.encoding,
+    fileformat: opts.ff ?? opts.fileformat,
+  });
+}
+
+export type ExecOptions = {
+  worktree?: string;
+  commitish?: string;
+  paths?: string[];
+  flags?: Flags;
+  encoding?: string;
+  fileformat?: string;
+};
+
+export async function exec(
+  denops: Denops,
+  bufnr: number,
+  options: ExecOptions,
+): Promise<void> {
+  const filenames = options.paths?.map((v) => v.replaceAll("\\", "/"));
+  const args = [
+    "log",
+    ...formatFlags(options.flags ?? {}),
+    ...unnullish(options.commitish, (v) => [v]) ?? [],
+    "--",
+    ...(filenames ?? []),
+  ];
+  await execBuffer(denops, bufnr, args, {
+    worktree: options.worktree,
+    encoding: options.encoding,
+    fileformat: options.fileformat,
+  });
+}

--- a/denops/gin/global.ts
+++ b/denops/gin/global.ts
@@ -6,4 +6,4 @@ export const GIN_BUFFER_PROTOCOLS = [
   "ginlog",
   "ginstatus",
 ];
-export const GIN_FILE_BUFFER_PROTOCOLS = ["gindiff", "ginedit"];
+export const GIN_FILE_BUFFER_PROTOCOLS = ["gindiff", "ginedit", "ginlog"];

--- a/denops/gin/util/expand.ts
+++ b/denops/gin/util/expand.ts
@@ -7,8 +7,14 @@ export async function expand(denops: Denops, expr: string): Promise<string> {
   const bufname = await fn.expand(denops, expr) as string;
   try {
     const { scheme, fragment } = parseBufname(bufname);
-    if (GIN_FILE_BUFFER_PROTOCOLS.includes(scheme)) {
-      return fragment ?? bufname;
+    if (fragment && GIN_FILE_BUFFER_PROTOCOLS.includes(scheme)) {
+      try {
+        // Return the first path if the buffer has multiple paths
+        const paths = JSON.parse(fragment);
+        return paths.at(0) ?? bufname;
+      } catch {
+        return fragment;
+      }
     }
   } catch {
     // Ignore errors

--- a/doc/gin.txt
+++ b/doc/gin.txt
@@ -387,6 +387,21 @@ example for details.
 	:silent execute 'Gin status'
 	:silent! execute 'GinEdit HEAD README.md'
 <
+							*gin-commands-file*
+Users can get a proper git path of gin's file like buffer with
+|gin#util#rexpand()| function. This function is used internally to resolve "%"
+applied to Gin command so users can switch between gin's file like buffers
+like
+>
+	" Open gin-edit buffer
+	:GinEdit --cached %
+
+	" Switch to gin-log buffer
+	:GinLog -- %
+
+	" Switch to gin-diff buffer
+	:GinDiff -- %
+<
 
 -----------------------------------------------------------------------------
 VARIABLES					*gin-variables*

--- a/plugin/gin-log.vim
+++ b/plugin/gin-log.vim
@@ -7,6 +7,8 @@ augroup gin_plugin_log_internal
   autocmd!
   autocmd BufReadCmd ginlog://*
         \ call denops#request('gin', 'log:edit', [bufnr(), expand('<amatch>')])
+  autocmd FileReadCmd ginlog://*
+        \ call denops#request('gin', 'log:read', [bufnr(), expand('<amatch>')])
 augroup END
 
 function! s:command(bang, mods, args) abort


### PR DESCRIPTION
Now users can use `gin#util#expand()` on `gin-edit`, `gin-diff`, and `gin-log` buffer so this PR close #75 