### PR TITLE
:package: Follow denops v5 changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,10 +55,10 @@ jobs:
           - macos-latest
           - ubuntu-latest
         version:
-          - "1.28.0"
+          - "1.32.0"
           - "1.x"
         host_version:
-          - vim: "v9.0.0472"
+          - vim: "v9.0.1499"
             nvim: "v0.8.0"
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.tools
+.tool-versions
 deno.lock

--- a/autoload/gin/util.vim
+++ b/autoload/gin/util.vim
@@ -2,8 +2,7 @@ let s:debounce_timers = {}
 
 function! gin#util#reload(...) abort
   let bufnr = a:0 ? a:1 : bufnr()
-  call denops#plugin#wait('gin')
-  call denops#request('gin', 'util:reload', [bufnr])
+  call denops#plugin#wait_async('gin', { -> denops#notify('gin','util:reload', [bufnr]) })
 endfunction
 
 function! gin#util#expand(expr) abort

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,8 +1,8 @@
 {
   "lock": false,
   "tasks": {
-    "test": "deno test --no-lock --unstable -A --doc --parallel --shuffle",
-    "check": "deno check --no-lock --unstable $(find . -name '*.ts')",
-    "upgrade": "deno run --no-lock -A https://deno.land/x/udd/main.ts $(find . -name '*.ts')"
+    "test": "deno test --unstable -A --doc --parallel --shuffle",
+    "check": "deno check --unstable $(find . -name '*.ts')",
+    "upgrade": "deno run -A https://deno.land/x/udd/main.ts $(find . -name '*.ts')"
   }
 }

--- a/denops/gin/action/add.ts
+++ b/denops/gin/action/add.ts
@@ -1,5 +1,5 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
 import { define, GatherCandidates, Range } from "./core.ts";
 import { exec as execBare } from "../command/bare/command.ts";
 

--- a/denops/gin/action/branch_delete.ts
+++ b/denops/gin/action/branch_delete.ts
@@ -1,5 +1,5 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
 import { define, GatherCandidates, Range } from "./core.ts";
 import { exec as execBare } from "../command/bare/command.ts";
 

--- a/denops/gin/action/branch_move.ts
+++ b/denops/gin/action/branch_move.ts
@@ -1,6 +1,6 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import * as helper from "https://deno.land/x/denops_std@v4.1.5/helper/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import * as helper from "https://deno.land/x/denops_std@v5.0.0/helper/mod.ts";
 import { define, GatherCandidates, Range } from "./core.ts";
 import { exec as execBare } from "../command/bare/command.ts";
 

--- a/denops/gin/action/branch_new.ts
+++ b/denops/gin/action/branch_new.ts
@@ -1,6 +1,6 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import * as helper from "https://deno.land/x/denops_std@v4.1.5/helper/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import * as helper from "https://deno.land/x/denops_std@v5.0.0/helper/mod.ts";
 import { define, GatherCandidates, Range } from "./core.ts";
 import { exec as execBare } from "../command/bare/command.ts";
 

--- a/denops/gin/action/chaperon.ts
+++ b/denops/gin/action/chaperon.ts
@@ -1,5 +1,5 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
 import { alias, define, GatherCandidates, Range } from "./core.ts";
 import {
   exec as execChaperon,

--- a/denops/gin/action/cherry_pick.ts
+++ b/denops/gin/action/cherry_pick.ts
@@ -1,5 +1,5 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
 import { define, GatherCandidates, Range } from "./core.ts";
 import { exec as execBare } from "../command/bare/command.ts";
 

--- a/denops/gin/action/core.ts
+++ b/denops/gin/action/core.ts
@@ -1,10 +1,10 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
-import * as fn from "https://deno.land/x/denops_std@v4.1.5/function/mod.ts";
-import * as helper from "https://deno.land/x/denops_std@v4.1.5/helper/mod.ts";
-import * as mapping from "https://deno.land/x/denops_std@v4.1.5/mapping/mod.ts";
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
+import * as fn from "https://deno.land/x/denops_std@v5.0.0/function/mod.ts";
+import * as helper from "https://deno.land/x/denops_std@v5.0.0/helper/mod.ts";
+import * as mapping from "https://deno.land/x/denops_std@v5.0.0/mapping/mod.ts";
+import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
 
 let rangeInternal: Range | undefined;
 
@@ -130,11 +130,11 @@ async function getRange(denops: Denops): Promise<Range> {
   if (rangeInternal) {
     return rangeInternal;
   }
-  const [mode, line1, line2] = await batch.gather(denops, async (denops) => {
-    await fn.mode(denops);
-    await fn.line(denops, ".");
-    await fn.line(denops, "v");
-  }) as [string, number, number];
+  const [mode, line1, line2] = await batch.collect(denops, (denops) => [
+    fn.mode(denops),
+    fn.line(denops, "."),
+    fn.line(denops, "v"),
+  ]);
   if (mode === "n") {
     return [line1, line1];
   }

--- a/denops/gin/action/diff.ts
+++ b/denops/gin/action/diff.ts
@@ -1,5 +1,5 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
 import { alias, define, GatherCandidates, Range } from "./core.ts";
 import {
   exec as execDiff,

--- a/denops/gin/action/diff_smart.ts
+++ b/denops/gin/action/diff_smart.ts
@@ -1,5 +1,5 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
 import { alias, define, GatherCandidates, Range } from "./core.ts";
 import { exec as execDiff } from "../command/diff/command.ts";
 

--- a/denops/gin/action/echo.ts
+++ b/denops/gin/action/echo.ts
@@ -1,6 +1,6 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import * as helper from "https://deno.land/x/denops_std@v4.1.5/helper/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import * as helper from "https://deno.land/x/denops_std@v5.0.0/helper/mod.ts";
 import { define, GatherCandidates, Range } from "./core.ts";
 
 export type Candidate = unknown;

--- a/denops/gin/action/edit.ts
+++ b/denops/gin/action/edit.ts
@@ -1,6 +1,6 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
 import { alias, define, GatherCandidates, Range } from "./core.ts";
 import {
   exec as execEdit,

--- a/denops/gin/action/merge.ts
+++ b/denops/gin/action/merge.ts
@@ -1,5 +1,5 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
 import { alias, define, GatherCandidates, Range } from "./core.ts";
 import { exec as execBare } from "../command/bare/command.ts";
 

--- a/denops/gin/action/patch.ts
+++ b/denops/gin/action/patch.ts
@@ -1,5 +1,5 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
 import { alias, define, GatherCandidates, Range } from "./core.ts";
 import {
   exec as execPatch,

--- a/denops/gin/action/rebase.ts
+++ b/denops/gin/action/rebase.ts
@@ -1,6 +1,6 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import * as helper from "https://deno.land/x/denops_std@v4.1.5/helper/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import * as helper from "https://deno.land/x/denops_std@v5.0.0/helper/mod.ts";
 import { define, GatherCandidates, Range } from "./core.ts";
 import { exec as execBare } from "../command/bare/command.ts";
 

--- a/denops/gin/action/reset.ts
+++ b/denops/gin/action/reset.ts
@@ -1,5 +1,5 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
 import { define, GatherCandidates, Range } from "./core.ts";
 import { exec as execBare } from "../command/bare/command.ts";
 

--- a/denops/gin/action/reset_file.ts
+++ b/denops/gin/action/reset_file.ts
@@ -1,5 +1,5 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
 import { define, GatherCandidates, Range } from "./core.ts";
 import { exec as execBare } from "../command/bare/command.ts";
 

--- a/denops/gin/action/restore.ts
+++ b/denops/gin/action/restore.ts
@@ -1,5 +1,5 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
 import { define, GatherCandidates, Range } from "./core.ts";
 import { exec as execBare } from "../command/bare/command.ts";
 

--- a/denops/gin/action/revert.ts
+++ b/denops/gin/action/revert.ts
@@ -1,5 +1,5 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
 import { define, GatherCandidates, Range } from "./core.ts";
 import { exec as execBare } from "../command/bare/command.ts";
 

--- a/denops/gin/action/rm.ts
+++ b/denops/gin/action/rm.ts
@@ -1,5 +1,5 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
 import { define, GatherCandidates, Range } from "./core.ts";
 import { exec as execBare } from "../command/bare/command.ts";
 

--- a/denops/gin/action/show.ts
+++ b/denops/gin/action/show.ts
@@ -1,5 +1,5 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
 import { alias, define, GatherCandidates, Range } from "./core.ts";
 import { exec as execBuffer } from "../command/buffer/command.ts";
 

--- a/denops/gin/action/stage.ts
+++ b/denops/gin/action/stage.ts
@@ -1,5 +1,5 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
 import { define, GatherCandidates, Range } from "./core.ts";
 import { exec as execBare } from "../command/bare/command.ts";
 import { doResetFile } from "./reset_file.ts";

--- a/denops/gin/action/stash.ts
+++ b/denops/gin/action/stash.ts
@@ -1,5 +1,5 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
 import { define, GatherCandidates, Range } from "./core.ts";
 import { exec as execBare } from "../command/bare/command.ts";
 

--- a/denops/gin/action/switch.ts
+++ b/denops/gin/action/switch.ts
@@ -1,5 +1,5 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
 import { define, GatherCandidates, Range } from "./core.ts";
 import { exec as execBare } from "../command/bare/command.ts";
 

--- a/denops/gin/action/tag.ts
+++ b/denops/gin/action/tag.ts
@@ -1,6 +1,6 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import * as helper from "https://deno.land/x/denops_std@v4.1.5/helper/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import * as helper from "https://deno.land/x/denops_std@v5.0.0/helper/mod.ts";
 import { alias, define, GatherCandidates, Range } from "./core.ts";
 import { exec as execBare } from "../command/bare/command.ts";
 

--- a/denops/gin/action/yank.ts
+++ b/denops/gin/action/yank.ts
@@ -1,7 +1,7 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import * as fn from "https://deno.land/x/denops_std@v4.1.5/function/mod.ts";
-import { v } from "https://deno.land/x/denops_std@v4.1.5/variable/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import * as fn from "https://deno.land/x/denops_std@v5.0.0/function/mod.ts";
+import { v } from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
 import { define, GatherCandidates, Range } from "./core.ts";
 
 export type Candidate = { value: string };

--- a/denops/gin/command/bare/command.ts
+++ b/denops/gin/command/bare/command.ts
@@ -1,7 +1,7 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as autocmd from "https://deno.land/x/denops_std@v4.1.5/autocmd/mod.ts";
-import * as helper from "https://deno.land/x/denops_std@v4.1.5/helper/mod.ts";
-import * as option from "https://deno.land/x/denops_std@v4.1.5/option/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as autocmd from "https://deno.land/x/denops_std@v5.0.0/autocmd/mod.ts";
+import * as helper from "https://deno.land/x/denops_std@v5.0.0/helper/mod.ts";
+import * as option from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
 import { removeAnsiEscapeCode } from "../../util/ansi_escape_code.ts";
 import { execute } from "../../git/executor.ts";
 

--- a/denops/gin/command/bare/main.ts
+++ b/denops/gin/command/bare/main.ts
@@ -1,10 +1,10 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import * as helper from "https://deno.land/x/denops_std@v4.1.5/helper/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import * as helper from "https://deno.land/x/denops_std@v5.0.0/helper/mod.ts";
 import {
   parseOpts,
   validateOpts,
-} from "https://deno.land/x/denops_std@v4.1.5/argument/opts.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/argument/opts.ts";
 import { normCmdArgs, parseSilent } from "../../util/cmd.ts";
 import { exec } from "./command.ts";
 

--- a/denops/gin/command/branch/command.ts
+++ b/denops/gin/command/branch/command.ts
@@ -1,9 +1,9 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import { unnullish } from "https://deno.land/x/unnullish@v1.0.0/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
-import * as option from "https://deno.land/x/denops_std@v4.1.5/option/mod.ts";
-import { format as formatBufname } from "https://deno.land/x/denops_std@v4.1.5/bufname/mod.ts";
-import { Flags } from "https://deno.land/x/denops_std@v4.1.5/argument/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import { unnullish } from "https://deno.land/x/unnullish@v1.0.1/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
+import * as option from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
+import { format as formatBufname } from "https://deno.land/x/denops_std@v5.0.0/bufname/mod.ts";
+import { Flags } from "https://deno.land/x/denops_std@v5.0.0/argument/mod.ts";
 import { findWorktreeFromDenops } from "../../git/worktree.ts";
 
 export type ExecOptions = {

--- a/denops/gin/command/branch/edit.ts
+++ b/denops/gin/command/branch/edit.ts
@@ -1,15 +1,15 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as fn from "https://deno.land/x/denops_std@v4.1.5/function/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
-import * as option from "https://deno.land/x/denops_std@v4.1.5/option/mod.ts";
-import * as vars from "https://deno.land/x/denops_std@v4.1.5/variable/mod.ts";
-import { parse as parseBufname } from "https://deno.land/x/denops_std@v4.1.5/bufname/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as fn from "https://deno.land/x/denops_std@v5.0.0/function/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
+import * as option from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
+import * as vars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
+import { parse as parseBufname } from "https://deno.land/x/denops_std@v5.0.0/bufname/mod.ts";
 import {
   Flags,
   formatFlags,
   parseOpts,
-} from "https://deno.land/x/denops_std@v4.1.5/argument/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/argument/mod.ts";
 import { bind } from "../../command/bare/command.ts";
 import { exec as execBuffer } from "../../command/buffer/edit.ts";
 import { init as initActionCore, Range } from "../../action/core.ts";

--- a/denops/gin/command/branch/main.ts
+++ b/denops/gin/command/branch/main.ts
@@ -1,14 +1,14 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as helper from "https://deno.land/x/denops_std@v4.1.5/helper/mod.ts";
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import * as vars from "https://deno.land/x/denops_std@v4.1.5/variable/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as helper from "https://deno.land/x/denops_std@v5.0.0/helper/mod.ts";
+import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import * as vars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
 import {
   builtinOpts,
   formatOpts,
   parse,
   validateFlags,
   validateOpts,
-} from "https://deno.land/x/denops_std@v4.1.5/argument/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/argument/mod.ts";
 
 import {
   normCmdArgs,

--- a/denops/gin/command/buffer/command.ts
+++ b/denops/gin/command/buffer/command.ts
@@ -1,10 +1,10 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import { unnullish } from "https://deno.land/x/unnullish@v1.0.0/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
-import * as option from "https://deno.land/x/denops_std@v4.1.5/option/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import { unnullish } from "https://deno.land/x/unnullish@v1.0.1/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
+import * as option from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
 import {
   format as formatBufname,
-} from "https://deno.land/x/denops_std@v4.1.5/bufname/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/bufname/mod.ts";
 import { findWorktreeFromDenops } from "../../git/worktree.ts";
 
 export type ExecOptions = {

--- a/denops/gin/command/buffer/edit.ts
+++ b/denops/gin/command/buffer/edit.ts
@@ -1,18 +1,18 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import { unnullish } from "https://deno.land/x/unnullish@v1.0.0/mod.ts";
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
-import * as option from "https://deno.land/x/denops_std@v4.1.5/option/mod.ts";
-import * as vars from "https://deno.land/x/denops_std@v4.1.5/variable/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import { unnullish } from "https://deno.land/x/unnullish@v1.0.1/mod.ts";
+import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
+import * as option from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
+import * as vars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
 import {
   builtinOpts,
   parseOpts,
   validateOpts,
-} from "https://deno.land/x/denops_std@v4.1.5/argument/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/argument/mod.ts";
 import {
   parse as parseBufname,
-} from "https://deno.land/x/denops_std@v4.1.5/bufname/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/bufname/mod.ts";
 import {
   buildDecorationsFromAnsiEscapeCode,
 } from "../../util/ansi_escape_code.ts";

--- a/denops/gin/command/buffer/main.ts
+++ b/denops/gin/command/buffer/main.ts
@@ -1,14 +1,14 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import { unnullish } from "https://deno.land/x/unnullish@v1.0.0/unnullish.ts";
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import * as helper from "https://deno.land/x/denops_std@v4.1.5/helper/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import { unnullish } from "https://deno.land/x/unnullish@v1.0.1/unnullish.ts";
+import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import * as helper from "https://deno.land/x/denops_std@v5.0.0/helper/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
 import {
   builtinOpts,
   formatOpts,
   parseOpts,
   validateOpts,
-} from "https://deno.land/x/denops_std@v4.1.5/argument/opts.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/argument/opts.ts";
 
 import { normCmdArgs, parseSilent } from "../../util/cmd.ts";
 import { exec } from "./command.ts";

--- a/denops/gin/command/buffer/read.ts
+++ b/denops/gin/command/buffer/read.ts
@@ -1,16 +1,16 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import { unnullish } from "https://deno.land/x/unnullish@v1.0.0/mod.ts";
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
-import * as vars from "https://deno.land/x/denops_std@v4.1.5/variable/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import { unnullish } from "https://deno.land/x/unnullish@v1.0.1/mod.ts";
+import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
+import * as vars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
 import {
   builtinOpts,
   parseOpts,
   validateOpts,
-} from "https://deno.land/x/denops_std@v4.1.5/argument/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/argument/mod.ts";
 import {
   parse as parseBufname,
-} from "https://deno.land/x/denops_std@v4.1.5/bufname/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/bufname/mod.ts";
 import { execute } from "../../git/executor.ts";
 
 export async function read(

--- a/denops/gin/command/chaperon/command.ts
+++ b/denops/gin/command/chaperon/command.ts
@@ -1,12 +1,12 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import * as fn from "https://deno.land/x/denops_std@v4.1.5/function/mod.ts";
-import * as mapping from "https://deno.land/x/denops_std@v4.1.5/mapping/mod.ts";
-import * as vars from "https://deno.land/x/denops_std@v4.1.5/variable/mod.ts";
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import * as path from "https://deno.land/std@0.184.0/path/mod.ts";
-import * as option from "https://deno.land/x/denops_std@v4.1.5/option/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import * as fn from "https://deno.land/x/denops_std@v5.0.0/function/mod.ts";
+import * as mapping from "https://deno.land/x/denops_std@v5.0.0/mapping/mod.ts";
+import * as vars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
+import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import * as path from "https://deno.land/std@0.188.0/path/mod.ts";
+import * as option from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
 import { findWorktreeFromDenops } from "../../git/worktree.ts";
 import { exec as execEdit } from "../edit/command.ts";
 import { AliasHead, getInProgressAliasHead, stripConflicts } from "./util.ts";
@@ -28,19 +28,19 @@ export async function exec(
 ): Promise<void> {
   const [verbose, noSupplements, supplementHeight, disableDefaultMappings] =
     await batch
-      .gather(
+      .collect(
         denops,
-        async (denops) => {
-          await option.verbose.get(denops);
-          await vars.g.get(denops, "gin_chaperon_supplement_disable", 0);
-          await vars.g.get(denops, "gin_chaperon_supplement_height", 10);
-          await vars.g.get(
+        (denops) => [
+          option.verbose.get(denops),
+          vars.g.get(denops, "gin_chaperon_supplement_disable", 0),
+          vars.g.get(denops, "gin_chaperon_supplement_height", 10),
+          vars.g.get(
             denops,
             "gin_chaperon_disable_default_mappings",
             false,
-          );
-        },
-      ) as [number, unknown, unknown, unknown];
+          ),
+        ],
+      );
   unknownutil.assertNumber(noSupplements);
   unknownutil.assertNumber(supplementHeight);
   unknownutil.assertBoolean(disableDefaultMappings);

--- a/denops/gin/command/chaperon/main.ts
+++ b/denops/gin/command/chaperon/main.ts
@@ -1,13 +1,13 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as vars from "https://deno.land/x/denops_std@v4.1.5/variable/mod.ts";
-import * as helper from "https://deno.land/x/denops_std@v4.1.5/helper/mod.ts";
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as vars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
+import * as helper from "https://deno.land/x/denops_std@v5.0.0/helper/mod.ts";
+import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
 import {
   builtinOpts,
   formatOpts,
   parse,
   validateOpts,
-} from "https://deno.land/x/denops_std@v4.1.5/argument/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/argument/mod.ts";
 import {
   normCmdArgs,
   parseDisableDefaultArgs,

--- a/denops/gin/command/chaperon/util.ts
+++ b/denops/gin/command/chaperon/util.ts
@@ -1,5 +1,5 @@
-import * as fs from "https://deno.land/std@0.184.0/fs/mod.ts";
-import * as path from "https://deno.land/std@0.184.0/path/mod.ts";
+import * as fs from "https://deno.land/std@0.188.0/fs/mod.ts";
+import * as path from "https://deno.land/std@0.188.0/path/mod.ts";
 
 const beginMarker = `${"<".repeat(7)} `;
 const endMarker = `${">".repeat(7)} `;

--- a/denops/gin/command/chaperon/util_test.ts
+++ b/denops/gin/command/chaperon/util_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.184.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.188.0/testing/asserts.ts";
 import { stripConflicts } from "./util.ts";
 
 // https://github.com/ojacobson/conflicts

--- a/denops/gin/command/diff/command.ts
+++ b/denops/gin/command/diff/command.ts
@@ -1,12 +1,12 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as path from "https://deno.land/std@0.184.0/path/mod.ts";
-import { unnullish } from "https://deno.land/x/unnullish@v1.0.0/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
-import * as option from "https://deno.land/x/denops_std@v4.1.5/option/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as path from "https://deno.land/std@0.188.0/path/mod.ts";
+import { unnullish } from "https://deno.land/x/unnullish@v1.0.1/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
+import * as option from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
 import {
   format as formatBufname,
-} from "https://deno.land/x/denops_std@v4.1.5/bufname/mod.ts";
-import { Flags } from "https://deno.land/x/denops_std@v4.1.5/argument/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/bufname/mod.ts";
+import { Flags } from "https://deno.land/x/denops_std@v5.0.0/argument/mod.ts";
 import { findWorktreeFromDenops } from "../../git/worktree.ts";
 
 export type ExecOptions = {

--- a/denops/gin/command/diff/commitish_test.ts
+++ b/denops/gin/command/diff/commitish_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.184.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.188.0/testing/asserts.ts";
 import { Commitish, INDEX, parseCommitish, WORKTREE } from "./commitish.ts";
 
 Deno.test("parseCommitish", () => {

--- a/denops/gin/command/diff/edit.ts
+++ b/denops/gin/command/diff/edit.ts
@@ -1,21 +1,21 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import { unnullish } from "https://deno.land/x/unnullish@v1.0.0/mod.ts";
-import { ensureString } from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import * as mapping from "https://deno.land/x/denops_std@v4.1.5/mapping/mod.ts";
-import * as option from "https://deno.land/x/denops_std@v4.1.5/option/mod.ts";
-import * as vars from "https://deno.land/x/denops_std@v4.1.5/variable/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import { unnullish } from "https://deno.land/x/unnullish@v1.0.1/mod.ts";
+import { ensureString } from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import * as mapping from "https://deno.land/x/denops_std@v5.0.0/mapping/mod.ts";
+import * as option from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
+import * as vars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
 import {
   parse as parseBufname,
-} from "https://deno.land/x/denops_std@v4.1.5/bufname/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/bufname/mod.ts";
 import {
   builtinOpts,
   Flags,
   formatFlags,
   parseOpts,
   validateOpts,
-} from "https://deno.land/x/denops_std@v4.1.5/argument/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/argument/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
 import { exec as execBuffer } from "../../command/buffer/edit.ts";
 
 export async function edit(

--- a/denops/gin/command/diff/jump.ts
+++ b/denops/gin/command/diff/jump.ts
@@ -1,12 +1,12 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import * as path from "https://deno.land/std@0.184.0/path/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
-import * as fn from "https://deno.land/x/denops_std@v4.1.5/function/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import * as path from "https://deno.land/std@0.188.0/path/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
+import * as fn from "https://deno.land/x/denops_std@v5.0.0/function/mod.ts";
 import {
   parse as parseBufname,
-} from "https://deno.land/x/denops_std@v4.1.5/bufname/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/bufname/mod.ts";
 import { exec as execEdit } from "../edit/command.ts";
 import { Commitish, INDEX, parseCommitish, WORKTREE } from "./commitish.ts";
 
@@ -114,15 +114,15 @@ async function jump(
   finder: Finder,
   parser: Parser,
 ): Promise<void> {
-  const [lnum, column, content, bufname] = await batch.gather(
+  const [lnum, column, content, bufname] = await batch.collect(
     denops,
-    async (denops) => {
-      await fn.line(denops, ".");
-      await fn.col(denops, ".");
-      await fn.getline(denops, 1, "$");
-      await fn.bufname(denops, "%");
-    },
-  ) as [number, number, string[], string];
+    (denops) => [
+      fn.line(denops, "."),
+      fn.col(denops, "."),
+      fn.getline(denops, 1, "$"),
+      fn.bufname(denops, "%"),
+    ],
+  );
   const { expr, params } = parseBufname(bufname);
   const jump = finder(lnum - 1, content);
   if (!jump) {

--- a/denops/gin/command/diff/jump_test.ts
+++ b/denops/gin/command/diff/jump_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.184.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.188.0/testing/asserts.ts";
 import { findJumpNew, findJumpOld, Jump } from "./jump.ts";
 
 const example = (await Deno.readTextFile(

--- a/denops/gin/command/diff/main.ts
+++ b/denops/gin/command/diff/main.ts
@@ -1,14 +1,14 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import * as helper from "https://deno.land/x/denops_std@v4.1.5/helper/mod.ts";
-import * as vars from "https://deno.land/x/denops_std@v4.1.5/variable/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import * as helper from "https://deno.land/x/denops_std@v5.0.0/helper/mod.ts";
+import * as vars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
 import {
   builtinOpts,
   formatOpts,
   parse,
   validateFlags,
   validateOpts,
-} from "https://deno.land/x/denops_std@v4.1.5/argument/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/argument/mod.ts";
 import {
   normCmdArgs,
   parseDisableDefaultArgs,

--- a/denops/gin/command/diff/read.ts
+++ b/denops/gin/command/diff/read.ts
@@ -1,17 +1,17 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import { unnullish } from "https://deno.land/x/unnullish@v1.0.0/mod.ts";
-import { ensureString } from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import * as vars from "https://deno.land/x/denops_std@v4.1.5/variable/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import { unnullish } from "https://deno.land/x/unnullish@v1.0.1/mod.ts";
+import { ensureString } from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import * as vars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
 import {
   parse as parseBufname,
-} from "https://deno.land/x/denops_std@v4.1.5/bufname/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/bufname/mod.ts";
 import {
   builtinOpts,
   Flags,
   formatFlags,
   parseOpts,
   validateOpts,
-} from "https://deno.land/x/denops_std@v4.1.5/argument/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/argument/mod.ts";
 import { exec as execBuffer } from "../../command/buffer/read.ts";
 
 export async function read(

--- a/denops/gin/command/edit/command.ts
+++ b/denops/gin/command/edit/command.ts
@@ -1,10 +1,10 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as path from "https://deno.land/std@0.184.0/path/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
-import * as option from "https://deno.land/x/denops_std@v4.1.5/option/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as path from "https://deno.land/std@0.188.0/path/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
+import * as option from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
 import {
   format as formatBufname,
-} from "https://deno.land/x/denops_std@v4.1.5/bufname/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/bufname/mod.ts";
 import { findWorktreeFromDenops } from "../../git/worktree.ts";
 
 export type ExecOptions = {

--- a/denops/gin/command/edit/edit.ts
+++ b/denops/gin/command/edit/edit.ts
@@ -1,18 +1,18 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import { ensureString } from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import { unnullish } from "https://deno.land/x/unnullish@v1.0.0/mod.ts";
-import * as autocmd from "https://deno.land/x/denops_std@v4.1.5/autocmd/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
-import * as option from "https://deno.land/x/denops_std@v4.1.5/option/mod.ts";
-import * as vars from "https://deno.land/x/denops_std@v4.1.5/variable/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import { ensureString } from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import { unnullish } from "https://deno.land/x/unnullish@v1.0.1/mod.ts";
+import * as autocmd from "https://deno.land/x/denops_std@v5.0.0/autocmd/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
+import * as option from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
+import * as vars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
 import {
   parseOpts,
   validateOpts,
-} from "https://deno.land/x/denops_std@v4.1.5/argument/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/argument/mod.ts";
 import {
   parse as parseBufname,
-} from "https://deno.land/x/denops_std@v4.1.5/bufname/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/bufname/mod.ts";
 import { execute } from "../../git/executor.ts";
 import { formatTreeish } from "./util.ts";
 

--- a/denops/gin/command/edit/main.ts
+++ b/denops/gin/command/edit/main.ts
@@ -1,13 +1,13 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import * as vars from "https://deno.land/x/denops_std@v4.1.5/variable/mod.ts";
-import * as helper from "https://deno.land/x/denops_std@v4.1.5/helper/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import * as vars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
+import * as helper from "https://deno.land/x/denops_std@v5.0.0/helper/mod.ts";
 import {
   builtinOpts,
   formatOpts,
   parseOpts,
   validateOpts,
-} from "https://deno.land/x/denops_std@v4.1.5/argument/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/argument/mod.ts";
 import {
   normCmdArgs,
   parseDisableDefaultArgs,

--- a/denops/gin/command/edit/read.ts
+++ b/denops/gin/command/edit/read.ts
@@ -1,15 +1,15 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import { ensureString } from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import { unnullish } from "https://deno.land/x/unnullish@v1.0.0/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
-import * as vars from "https://deno.land/x/denops_std@v4.1.5/variable/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import { ensureString } from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import { unnullish } from "https://deno.land/x/unnullish@v1.0.1/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
+import * as vars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
 import {
   parseOpts,
   validateOpts,
-} from "https://deno.land/x/denops_std@v4.1.5/argument/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/argument/mod.ts";
 import {
   parse as parseBufname,
-} from "https://deno.land/x/denops_std@v4.1.5/bufname/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/bufname/mod.ts";
 import { execute } from "../../git/executor.ts";
 import { formatTreeish } from "./util.ts";
 

--- a/denops/gin/command/edit/util.ts
+++ b/denops/gin/command/edit/util.ts
@@ -1,4 +1,4 @@
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
+import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
 
 export function formatTreeish(
   commitish: string | string[] | undefined,

--- a/denops/gin/command/edit/write.ts
+++ b/denops/gin/command/edit/write.ts
@@ -1,12 +1,12 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as path from "https://deno.land/std@0.184.0/path/mod.ts";
-import * as fs from "https://deno.land/std@0.184.0/fs/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import * as fn from "https://deno.land/x/denops_std@v4.1.5/function/mod.ts";
-import * as option from "https://deno.land/x/denops_std@v4.1.5/option/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as path from "https://deno.land/std@0.188.0/path/mod.ts";
+import * as fs from "https://deno.land/std@0.188.0/fs/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import * as fn from "https://deno.land/x/denops_std@v5.0.0/function/mod.ts";
+import * as option from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
 import {
   parse as parseBufname,
-} from "https://deno.land/x/denops_std@v4.1.5/bufname/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/bufname/mod.ts";
 import { findWorktreeFromDenops } from "../../git/worktree.ts";
 import { exec as execBare } from "../../command/bare/command.ts";
 
@@ -34,15 +34,15 @@ export async function exec(
   relpath: string,
   options: ExecOptions,
 ): Promise<void> {
-  const [verbose, fileencoding, fileformat, content] = await batch.gather(
+  const [verbose, fileencoding, fileformat, content] = await batch.collect(
     denops,
-    async (denops) => {
-      await option.verbose.get(denops);
-      await fn.getbufvar(denops, bufnr, "&fileencoding");
-      await fn.getbufvar(denops, bufnr, "&fileformat");
-      await fn.getbufline(denops, bufnr, 1, "$");
-    },
-  ) as [number, string, string, string[]];
+    (denops) => [
+      option.verbose.get(denops),
+      option.fileencoding.getBuffer(denops, bufnr),
+      option.fileformat.getBuffer(denops, bufnr),
+      fn.getbufline(denops, bufnr, 1, "$"),
+    ],
+  );
 
   const worktree = await findWorktreeFromDenops(denops, {
     worktree: options.worktree,

--- a/denops/gin/command/log/command.ts
+++ b/denops/gin/command/log/command.ts
@@ -1,12 +1,12 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as path from "https://deno.land/std@0.184.0/path/mod.ts";
-import { unnullish } from "https://deno.land/x/unnullish@v1.0.0/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
-import * as option from "https://deno.land/x/denops_std@v4.1.5/option/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as path from "https://deno.land/std@0.188.0/path/mod.ts";
+import { unnullish } from "https://deno.land/x/unnullish@v1.0.1/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
+import * as option from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
 import {
   format as formatBufname,
-} from "https://deno.land/x/denops_std@v4.1.5/bufname/mod.ts";
-import { Flags } from "https://deno.land/x/denops_std@v4.1.5/argument/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/bufname/mod.ts";
+import { Flags } from "https://deno.land/x/denops_std@v5.0.0/argument/mod.ts";
 import { findWorktreeFromDenops } from "../../git/worktree.ts";
 
 export type ExecOptions = {

--- a/denops/gin/command/log/edit.ts
+++ b/denops/gin/command/log/edit.ts
@@ -1,19 +1,19 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import { unnullish } from "https://deno.land/x/unnullish@v1.0.0/mod.ts";
-import { ensureString } from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import * as fn from "https://deno.land/x/denops_std@v4.1.5/function/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
-import * as option from "https://deno.land/x/denops_std@v4.1.5/option/mod.ts";
-import * as vars from "https://deno.land/x/denops_std@v4.1.5/variable/mod.ts";
-import { parse as parseBufname } from "https://deno.land/x/denops_std@v4.1.5/bufname/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import { unnullish } from "https://deno.land/x/unnullish@v1.0.1/mod.ts";
+import { ensureString } from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import * as fn from "https://deno.land/x/denops_std@v5.0.0/function/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
+import * as option from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
+import * as vars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
+import { parse as parseBufname } from "https://deno.land/x/denops_std@v5.0.0/bufname/mod.ts";
 import {
   builtinOpts,
   Flags,
   formatFlags,
   parseOpts,
   validateOpts,
-} from "https://deno.land/x/denops_std@v4.1.5/argument/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/argument/mod.ts";
 import { bind } from "../../command/bare/command.ts";
 import { exec as execBuffer } from "../../command/buffer/edit.ts";
 import { init as initActionCore, Range } from "../../action/core.ts";
@@ -111,16 +111,16 @@ async function gatherCandidates(
   bufnr: number,
   [start, end]: Range,
 ): Promise<Entry[]> {
-  const [content, patternStr] = await batch.gather(denops, async (denops) => {
-    await fn.getbufline(
+  const [content, patternStr] = await batch.collect(denops, (denops) => [
+    fn.getbufline(
       denops,
       bufnr,
       Math.max(start, 1),
       Math.max(end, 1),
-    );
-    await vars.g.get(denops, "gin_log_parse_pattern");
-  }) as [string[], string | undefined];
-  const pattern = unnullish(patternStr, (v) => new RegExp(v));
+    ),
+    vars.g.get(denops, "gin_log_parse_pattern"),
+  ]);
+  const pattern = unnullish(patternStr, (v) => new RegExp(ensureString(v)));
   const result = parseLog(content, pattern);
   return result.entries;
 }

--- a/denops/gin/command/log/main.ts
+++ b/denops/gin/command/log/main.ts
@@ -1,14 +1,14 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as helper from "https://deno.land/x/denops_std@v4.1.5/helper/mod.ts";
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import * as vars from "https://deno.land/x/denops_std@v4.1.5/variable/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as helper from "https://deno.land/x/denops_std@v5.0.0/helper/mod.ts";
+import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import * as vars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
 import {
   builtinOpts,
   formatOpts,
   parse,
   validateFlags,
   validateOpts,
-} from "https://deno.land/x/denops_std@v4.1.5/argument/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/argument/mod.ts";
 import {
   normCmdArgs,
   parseDisableDefaultArgs,

--- a/denops/gin/command/log/parser_test.ts
+++ b/denops/gin/command/log/parser_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.184.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.188.0/testing/asserts.ts";
 import { parse } from "./parser.ts";
 
 Deno.test(`parse (with --decorate=full`, () => {

--- a/denops/gin/command/log/read.ts
+++ b/denops/gin/command/log/read.ts
@@ -1,17 +1,17 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import { unnullish } from "https://deno.land/x/unnullish@v1.0.0/mod.ts";
-import { ensureString } from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import * as vars from "https://deno.land/x/denops_std@v4.1.5/variable/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import { unnullish } from "https://deno.land/x/unnullish@v1.0.1/mod.ts";
+import { ensureString } from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import * as vars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
 import {
   parse as parseBufname,
-} from "https://deno.land/x/denops_std@v4.1.5/bufname/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/bufname/mod.ts";
 import {
   builtinOpts,
   Flags,
   formatFlags,
   parseOpts,
   validateOpts,
-} from "https://deno.land/x/denops_std@v4.1.5/argument/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/argument/mod.ts";
 import { exec as execBuffer } from "../../command/buffer/read.ts";
 
 export async function read(

--- a/denops/gin/command/patch/command.ts
+++ b/denops/gin/command/patch/command.ts
@@ -1,12 +1,12 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as path from "https://deno.land/std@0.184.0/path/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import * as fn from "https://deno.land/x/denops_std@v4.1.5/function/mod.ts";
-import * as mapping from "https://deno.land/x/denops_std@v4.1.5/mapping/mod.ts";
-import * as vars from "https://deno.land/x/denops_std@v4.1.5/variable/mod.ts";
-import * as option from "https://deno.land/x/denops_std@v4.1.5/option/mod.ts";
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as path from "https://deno.land/std@0.188.0/path/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import * as fn from "https://deno.land/x/denops_std@v5.0.0/function/mod.ts";
+import * as mapping from "https://deno.land/x/denops_std@v5.0.0/mapping/mod.ts";
+import * as vars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
+import * as option from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
+import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
 import { findWorktreeFromDenops } from "../../git/worktree.ts";
 import { exec as execEdit } from "../edit/command.ts";
 
@@ -25,17 +25,17 @@ export async function exec(
   filename: string,
   options: ExecOptions = {},
 ): Promise<void> {
-  const [verbose, disableDefaultMappings] = await batch.gather(
+  const [verbose, disableDefaultMappings] = await batch.collect(
     denops,
-    async (denops) => {
-      await option.verbose.get(denops);
-      await vars.g.get(
+    (denops) => [
+      option.verbose.get(denops),
+      vars.g.get(
         denops,
         "gin_patch_disable_default_mappings",
         false,
-      );
-    },
-  ) as [number, unknown];
+      ),
+    ],
+  );
   unknownutil.assertBoolean(disableDefaultMappings);
 
   const worktree = await findWorktreeFromDenops(denops, {

--- a/denops/gin/command/patch/main.ts
+++ b/denops/gin/command/patch/main.ts
@@ -1,13 +1,13 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as helper from "https://deno.land/x/denops_std@v4.1.5/helper/mod.ts";
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import * as vars from "https://deno.land/x/denops_std@v4.1.5/variable/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as helper from "https://deno.land/x/denops_std@v5.0.0/helper/mod.ts";
+import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import * as vars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
 import {
   builtinOpts,
   formatOpts,
   parse,
   validateOpts,
-} from "https://deno.land/x/denops_std@v4.1.5/argument/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/argument/mod.ts";
 import {
   normCmdArgs,
   parseDisableDefaultArgs,

--- a/denops/gin/command/status/command.ts
+++ b/denops/gin/command/status/command.ts
@@ -1,11 +1,11 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import { unnullish } from "https://deno.land/x/unnullish@v1.0.0/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
-import * as option from "https://deno.land/x/denops_std@v4.1.5/option/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import { unnullish } from "https://deno.land/x/unnullish@v1.0.1/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
+import * as option from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
 import {
   format as formatBufname,
-} from "https://deno.land/x/denops_std@v4.1.5/bufname/mod.ts";
-import { Flags } from "https://deno.land/x/denops_std@v4.1.5/argument/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/bufname/mod.ts";
+import { Flags } from "https://deno.land/x/denops_std@v5.0.0/argument/mod.ts";
 import { findWorktreeFromDenops } from "../../git/worktree.ts";
 
 export type ExecOptions = {

--- a/denops/gin/command/status/edit.ts
+++ b/denops/gin/command/status/edit.ts
@@ -1,18 +1,18 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import { unnullish } from "https://deno.land/x/unnullish@v1.0.0/mod.ts";
-import * as path from "https://deno.land/std@0.184.0/path/mod.ts";
-import * as autocmd from "https://deno.land/x/denops_std@v4.1.5/autocmd/mod.ts";
-import * as fn from "https://deno.land/x/denops_std@v4.1.5/function/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
-import * as option from "https://deno.land/x/denops_std@v4.1.5/option/mod.ts";
-import * as vars from "https://deno.land/x/denops_std@v4.1.5/variable/mod.ts";
-import { parse as parseBufname } from "https://deno.land/x/denops_std@v4.1.5/bufname/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import { unnullish } from "https://deno.land/x/unnullish@v1.0.1/mod.ts";
+import * as path from "https://deno.land/std@0.188.0/path/mod.ts";
+import * as autocmd from "https://deno.land/x/denops_std@v5.0.0/autocmd/mod.ts";
+import * as fn from "https://deno.land/x/denops_std@v5.0.0/function/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
+import * as option from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
+import * as vars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
+import { parse as parseBufname } from "https://deno.land/x/denops_std@v5.0.0/bufname/mod.ts";
 import {
   Flags,
   formatFlags,
   parseOpts,
-} from "https://deno.land/x/denops_std@v4.1.5/argument/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/argument/mod.ts";
 import { bind } from "../../command/bare/command.ts";
 import { exec as execBuffer } from "../../command/buffer/edit.ts";
 import { findWorktreeFromDenops } from "../../git/worktree.ts";

--- a/denops/gin/command/status/main.ts
+++ b/denops/gin/command/status/main.ts
@@ -1,14 +1,14 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as helper from "https://deno.land/x/denops_std@v4.1.5/helper/mod.ts";
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import * as vars from "https://deno.land/x/denops_std@v4.1.5/variable/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as helper from "https://deno.land/x/denops_std@v5.0.0/helper/mod.ts";
+import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import * as vars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
 import {
   builtinOpts,
   formatOpts,
   parse,
   validateFlags,
   validateOpts,
-} from "https://deno.land/x/denops_std@v4.1.5/argument/mod.ts";
+} from "https://deno.land/x/denops_std@v5.0.0/argument/mod.ts";
 import {
   normCmdArgs,
   parseDisableDefaultArgs,

--- a/denops/gin/command/status/parser_test.ts
+++ b/denops/gin/command/status/parser_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.184.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.188.0/testing/asserts.ts";
 import { parse } from "./parser.ts";
 
 Deno.test(`parse`, () => {

--- a/denops/gin/component/branch.ts
+++ b/denops/gin/component/branch.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
 import { Cache } from "https://deno.land/x/local_cache@1.0/mod.ts";
 import { decodeUtf8 } from "../util/text.ts";
 import { findWorktreeFromDenops } from "../git/worktree.ts";

--- a/denops/gin/component/traffic.ts
+++ b/denops/gin/component/traffic.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
 import { Cache } from "https://deno.land/x/local_cache@1.0/mod.ts";
 import { decodeUtf8 } from "../util/text.ts";
 import { findWorktreeFromDenops } from "../git/worktree.ts";

--- a/denops/gin/component/worktree.ts
+++ b/denops/gin/component/worktree.ts
@@ -1,6 +1,6 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
 import { Cache } from "https://deno.land/x/local_cache@1.0/mod.ts";
-import * as path from "https://deno.land/std@0.184.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.188.0/path/mod.ts";
 import { findWorktreeFromDenops } from "../git/worktree.ts";
 import { find } from "../git/finder.ts";
 

--- a/denops/gin/git/executor.ts
+++ b/denops/gin/git/executor.ts
@@ -1,8 +1,8 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import { writeAll } from "https://deno.land/std@0.184.0/streams/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import * as fn from "https://deno.land/x/denops_std@v4.1.5/function/mod.ts";
-import * as option from "https://deno.land/x/denops_std@v4.1.5/option/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import { writeAll } from "https://deno.land/std@0.188.0/streams/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import * as fn from "https://deno.land/x/denops_std@v5.0.0/function/mod.ts";
+import * as option from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
 import { decodeUtf8 } from "../util/text.ts";
 import { removeAnsiEscapeCode } from "../util/ansi_escape_code.ts";
 import { findWorktreeFromDenops } from "./worktree.ts";
@@ -42,13 +42,13 @@ export async function execute(
   args: string[],
   options: ExecuteOptions = {},
 ): Promise<ExecuteResult> {
-  const [env, verbose] = await batch.gather(
+  const [env, verbose] = await batch.collect(
     denops,
-    async (denops) => {
-      await fn.environ(denops);
-      await option.verbose.get(denops);
-    },
-  ) as [Record<string, string>, number];
+    (denops) => [
+      fn.environ(denops) as Promise<Record<string, string>>,
+      option.verbose.get(denops),
+    ],
+  );
 
   const worktree = await findWorktreeFromDenops(denops, {
     worktree: options.worktree,

--- a/denops/gin/git/finder.ts
+++ b/denops/gin/git/finder.ts
@@ -1,5 +1,5 @@
 import { Cache } from "https://deno.land/x/local_cache@1.0/mod.ts";
-import * as path from "https://deno.land/std@0.184.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.188.0/path/mod.ts";
 import { execute } from "./process.ts";
 import { decodeUtf8 } from "../util/text.ts";
 

--- a/denops/gin/git/finder_test.ts
+++ b/denops/gin/git/finder_test.ts
@@ -1,8 +1,8 @@
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.184.0/testing/asserts.ts";
-import * as path from "https://deno.land/std@0.184.0/path/mod.ts";
+} from "https://deno.land/std@0.188.0/testing/asserts.ts";
+import * as path from "https://deno.land/std@0.188.0/path/mod.ts";
 import { find } from "./finder.ts";
 import { ExecuteError } from "./process.ts";
 

--- a/denops/gin/git/process_test.ts
+++ b/denops/gin/git/process_test.ts
@@ -1,7 +1,7 @@
 import {
   assert,
   assertRejects,
-} from "https://deno.land/std@0.184.0/testing/asserts.ts";
+} from "https://deno.land/std@0.188.0/testing/asserts.ts";
 import { decodeUtf8 } from "../util/text.ts";
 import { execute, ExecuteError, run } from "./process.ts";
 

--- a/denops/gin/git/worktree.ts
+++ b/denops/gin/git/worktree.ts
@@ -1,9 +1,8 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import { parse as parseBufname } from "https://deno.land/x/denops_std@v4.1.5/bufname/mod.ts";
-import * as fn from "https://deno.land/x/denops_std@v4.1.5/function/mod.ts";
-import * as path from "https://deno.land/std@0.184.0/path/mod.ts";
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import { parse as parseBufname } from "https://deno.land/x/denops_std@v5.0.0/bufname/mod.ts";
+import * as fn from "https://deno.land/x/denops_std@v5.0.0/function/mod.ts";
+import * as path from "https://deno.land/std@0.188.0/path/mod.ts";
 import { GIN_BUFFER_PROTOCOLS } from "../global.ts";
 import { expand } from "../util/expand.ts";
 import { find } from "./finder.ts";
@@ -70,15 +69,13 @@ async function listWorktreeSuspectsFromDenops(
   denops: Denops,
   verbose?: boolean,
 ): Promise<string[]> {
-  const [cwd, bufname] = await batch.gather(
+  const [cwd, bufname] = await batch.collect(
     denops,
-    async (denops) => {
-      await fn.getcwd(denops);
-      await fn.expand(denops, "%:p");
-    },
+    (denops) => [
+      fn.getcwd(denops),
+      fn.expand(denops, "%:p") as Promise<string>,
+    ],
   );
-  unknownutil.assertString(cwd);
-  unknownutil.assertString(bufname);
   if (verbose) {
     console.debug("listWorktreeSuspectsFromDenops");
     console.debug(`  cwd: ${cwd}`);

--- a/denops/gin/main.ts
+++ b/denops/gin/main.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
 
 import { main as mainBare } from "./command/bare/main.ts";
 import { main as mainBuffer } from "./command/buffer/main.ts";

--- a/denops/gin/proxy/askpass.ts
+++ b/denops/gin/proxy/askpass.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S deno run --no-check --allow-env=GIN_PROXY_ADDRESS --allow-net=127.0.0.1
-import * as streams from "https://deno.land/std@0.184.0/streams/mod.ts";
+import * as streams from "https://deno.land/std@0.188.0/streams/mod.ts";
 
 const resultPattern = /^([^:]+):(.*)$/;
 

--- a/denops/gin/proxy/editor.ts
+++ b/denops/gin/proxy/editor.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S deno run --no-check --allow-env=GIN_PROXY_ADDRESS --allow-net=127.0.0.1
-import * as streams from "https://deno.land/std@0.184.0/streams/mod.ts";
+import * as streams from "https://deno.land/std@0.188.0/streams/mod.ts";
 
 const resultPattern = /^([^:]+):(.*)$/;
 

--- a/denops/gin/proxy/main.ts
+++ b/denops/gin/proxy/main.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
 import { listen } from "./server.ts";
 
 export function main(denops: Denops): void {

--- a/denops/gin/proxy/server.ts
+++ b/denops/gin/proxy/server.ts
@@ -1,14 +1,14 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as anonymous from "https://deno.land/x/denops_std@v4.1.5/anonymous/mod.ts";
-import * as autocmd from "https://deno.land/x/denops_std@v4.1.5/autocmd/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
-import * as fn from "https://deno.land/x/denops_std@v4.1.5/function/mod.ts";
-import * as vars from "https://deno.land/x/denops_std@v4.1.5/variable/mod.ts";
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import * as path from "https://deno.land/std@0.184.0/path/mod.ts";
-import * as streams from "https://deno.land/std@0.184.0/streams/mod.ts";
-import { deferred } from "https://deno.land/std@0.184.0/async/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as lambda from "https://deno.land/x/denops_std@v5.0.0/lambda/mod.ts";
+import * as autocmd from "https://deno.land/x/denops_std@v5.0.0/autocmd/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
+import * as fn from "https://deno.land/x/denops_std@v5.0.0/function/mod.ts";
+import * as vars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
+import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import * as path from "https://deno.land/std@0.188.0/path/mod.ts";
+import * as streams from "https://deno.land/std@0.188.0/streams/mod.ts";
+import { deferred } from "https://deno.land/std@0.188.0/async/mod.ts";
 import { decodeUtf8, encodeUtf8 } from "../util/text.ts";
 
 const recordPattern = /^([^:]+?):(.*)$/;
@@ -18,12 +18,12 @@ export async function listen(denops: Denops): Promise<void> {
     hostname: "127.0.0.1",
     port: 0,
   });
-  const [disableAskpass, disableEditor] = await batch.gather(
+  const [disableAskpass, disableEditor] = await batch.collect(
     denops,
-    async (denops) => {
-      await vars.g.get(denops, "gin_proxy_disable_askpass");
-      await vars.g.get(denops, "gin_proxy_disable_editor");
-    },
+    (denops) => [
+      vars.g.get(denops, "gin_proxy_disable_askpass"),
+      vars.g.get(denops, "gin_proxy_disable_editor"),
+    ],
   );
   await batch.batch(denops, async (denops) => {
     await vars.e.set(
@@ -130,9 +130,9 @@ async function edit(
 
   const auname = `gin_editor_${winid}_${bufnr}`;
   const waiter = deferred<void>();
-  const [waiterId] = anonymous.once(denops, () => {
+  const waiterId = lambda.register(denops, () => {
     waiter.resolve();
-  });
+  }, { once: true });
   await batch.batch(denops, async (denops) => {
     await autocmd.group(denops, auname, (helper) => {
       helper.remove("*", `<buffer=${bufnr}>`);

--- a/denops/gin/util/ansi_escape_code.ts
+++ b/denops/gin/util/ansi_escape_code.ts
@@ -1,14 +1,14 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
 import {
   assertArray,
   isNumber,
   isString,
-} from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import { unnullish } from "https://deno.land/x/unnullish@v1.0.0/mod.ts";
-import * as itertools from "https://deno.land/x/itertools@v1.1.0/mod.ts";
-import * as ansiEscapeCode from "https://deno.land/x/ansi_escape_code@v1.0.0/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import { Decoration } from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
+} from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import { unnullish } from "https://deno.land/x/unnullish@v1.0.1/mod.ts";
+import * as itertools from "https://deno.land/x/itertools@v1.1.1/mod.ts";
+import * as ansiEscapeCode from "https://deno.land/x/ansi_escape_code@v1.0.2/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import { Decoration } from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
 import { countVimBytes } from "./text.ts";
 
 export function removeAnsiEscapeCode(

--- a/denops/gin/util/cmd.ts
+++ b/denops/gin/util/cmd.ts
@@ -1,5 +1,5 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import { Silent } from "https://deno.land/x/denops_std@v4.1.5/helper/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import { Silent } from "https://deno.land/x/denops_std@v5.0.0/helper/mod.ts";
 import { expand } from "./expand.ts";
 
 export function parseDisableDefaultArgs(args: string[]): [boolean, string[]] {

--- a/denops/gin/util/cmd_test.ts
+++ b/denops/gin/util/cmd_test.ts
@@ -1,10 +1,10 @@
-import { assertEquals } from "https://deno.land/std@0.184.0/testing/asserts.ts";
-import { test } from "https://deno.land/x/denops_test@v1.1.0/mod.ts";
-import * as batch from "https://deno.land/x/denops_std@v4.1.5/batch/mod.ts";
-import * as fn from "https://deno.land/x/denops_std@v4.1.5/function/mod.ts";
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import * as path from "https://deno.land/std@0.184.0/path/mod.ts";
-import { deadline } from "https://deno.land/std@0.184.0/async/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.188.0/testing/asserts.ts";
+import { test } from "https://deno.land/x/denops_test@v1.3.1/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+import * as fn from "https://deno.land/x/denops_std@v5.0.0/function/mod.ts";
+import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import * as path from "https://deno.land/std@0.188.0/path/mod.ts";
+import { deadline } from "https://deno.land/std@0.188.0/async/mod.ts";
 import { normCmdArgs } from "./cmd.ts";
 
 const runtimepath = path.resolve(

--- a/denops/gin/util/expand.ts
+++ b/denops/gin/util/expand.ts
@@ -1,6 +1,6 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as fn from "https://deno.land/x/denops_std@v4.1.5/function/mod.ts";
-import { parse as parseBufname } from "https://deno.land/x/denops_std@v4.1.5/bufname/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as fn from "https://deno.land/x/denops_std@v5.0.0/function/mod.ts";
+import { parse as parseBufname } from "https://deno.land/x/denops_std@v5.0.0/bufname/mod.ts";
 import { GIN_FILE_BUFFER_PROTOCOLS } from "../global.ts";
 
 export async function expand(denops: Denops, expr: string): Promise<string> {

--- a/denops/gin/util/main.ts
+++ b/denops/gin/util/main.ts
@@ -1,6 +1,6 @@
-import type { Denops } from "https://deno.land/x/denops_std@v4.1.5/mod.ts";
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
-import * as buffer from "https://deno.land/x/denops_std@v4.1.5/buffer/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import * as buffer from "https://deno.land/x/denops_std@v5.0.0/buffer/mod.ts";
 import { expand } from "./expand.ts";
 import { findWorktreeFromDenops } from "../git/worktree.ts";
 

--- a/denops/gin/util/text_test.ts
+++ b/denops/gin/util/text_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.184.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.188.0/testing/asserts.ts";
 import {
   countCodePoints,
   countVimBytes,


### PR DESCRIPTION
SSIA

Lint would fail while `Deno.run` is used.