### PR TITLE
:+1: Add `++emojify` options to `GinBuffer` and `GinLog`

### DIFF
--- a/denops/gin/action/show.ts
+++ b/denops/gin/action/show.ts
@@ -23,7 +23,14 @@ export async function init(
         bufnr,
         `show:${opener}`,
         (denops, bufnr, range) =>
-          doShow(denops, bufnr, range, opener, gatherCandidates),
+          doShow(denops, bufnr, range, opener, false, gatherCandidates),
+      );
+      await define(
+        denops,
+        bufnr,
+        `show:${opener}:emojify`,
+        (denops, bufnr, range) =>
+          doShow(denops, bufnr, range, opener, true, gatherCandidates),
       );
     }
     await alias(
@@ -31,6 +38,12 @@ export async function init(
       bufnr,
       "show",
       "show:edit",
+    );
+    await alias(
+      denops,
+      bufnr,
+      "show:emojify",
+      "show:edit:emojify",
     );
   });
 }
@@ -40,12 +53,14 @@ async function doShow(
   bufnr: number,
   range: Range,
   opener: string,
+  emojify: boolean,
   gatherCandidates: GatherCandidates<Candidate>,
 ): Promise<void> {
   const xs = await gatherCandidates(denops, bufnr, range);
   for (const x of xs) {
     await execBuffer(denops, ["show", x.commit], {
       opener,
+      emojify,
     });
   }
 }

--- a/denops/gin/command/buffer/command.ts
+++ b/denops/gin/command/buffer/command.ts
@@ -12,6 +12,7 @@ export type ExecOptions = {
   worktree?: string;
   monochrome?: boolean;
   opener?: string;
+  emojify?: boolean;
   cmdarg?: string;
   mods?: string;
   bang?: boolean;
@@ -33,6 +34,7 @@ export async function exec(
     params: {
       processor: unnullish(options.processor, (v) => v.join(" ")),
       monochrome: unnullish(options.monochrome, (v) => v ? "" : undefined),
+      emojify: unnullish(options.emojify, (v) => v ? "" : undefined),
     },
     fragment: `${args.join(" ")}$`,
   });

--- a/denops/gin/command/buffer/edit.ts
+++ b/denops/gin/command/buffer/edit.ts
@@ -1,4 +1,5 @@
 import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
+import { emojify } from "https://deno.land/x/github_emoji@v0.1.1/mod.ts";
 import { unnullish } from "https://deno.land/x/unnullish@v1.0.1/mod.ts";
 import { ensure, is } from "https://deno.land/x/unknownutil@v3.0.0/mod.ts#^";
 import * as batch from "https://deno.land/x/denops_std@v5.0.1/batch/mod.ts";
@@ -43,6 +44,7 @@ export async function edit(
     monochrome: "monochrome" in (params ?? {}),
     encoding: opts.enc ?? opts.encoding,
     fileformat: opts.ff ?? opts.fileformat,
+    emojify: "emojify" in (params ?? {}),
   });
 }
 
@@ -52,6 +54,7 @@ export type ExecOptions = {
   monochrome?: boolean;
   encoding?: string;
   fileformat?: string;
+  emojify?: boolean;
   stdoutIndicator?: string;
   stderrIndicator?: string;
 };
@@ -96,10 +99,15 @@ export async function exec(
     denops,
     content,
   );
-  await buffer.replace(denops, bufnr, trimmed, {
-    fileformat,
-    fileencoding,
-  });
+  await buffer.replace(
+    denops,
+    bufnr,
+    options.emojify ? trimmed.map(emojify) : trimmed,
+    {
+      fileformat,
+      fileencoding,
+    },
+  );
   await buffer.decorate(denops, bufnr, decorations);
   await buffer.concrete(denops, bufnr);
   await buffer.ensure(denops, bufnr, async () => {

--- a/denops/gin/command/buffer/main.ts
+++ b/denops/gin/command/buffer/main.ts
@@ -61,6 +61,7 @@ async function command(
     "worktree",
     "monochrome",
     "opener",
+    "emojify",
     ...builtinOpts,
   ]);
   return exec(denops, residue, {
@@ -68,6 +69,7 @@ async function command(
     worktree: opts.worktree,
     monochrome: unnullish(opts.monochrome, () => true),
     opener: opts.opener,
+    emojify: unnullish(opts.emojify, () => true),
     cmdarg: formatOpts(opts, builtinOpts).join(" "),
     mods,
     bang: bang === "!",

--- a/denops/gin/command/buffer/read.ts
+++ b/denops/gin/command/buffer/read.ts
@@ -1,4 +1,5 @@
 import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
+import { emojify } from "https://deno.land/x/github_emoji@v0.1.1/mod.ts";
 import { unnullish } from "https://deno.land/x/unnullish@v1.0.1/mod.ts";
 import { ensure, is } from "https://deno.land/x/unknownutil@v3.0.0/mod.ts#^";
 import * as buffer from "https://deno.land/x/denops_std@v5.0.1/buffer/mod.ts";
@@ -37,6 +38,7 @@ export async function read(
     worktree: expr,
     encoding: opts.enc ?? opts.encoding,
     fileformat: opts.ff ?? opts.fileformat,
+    emojify: "emojify" in (params ?? {}),
   });
 }
 
@@ -45,6 +47,7 @@ export type ExecOptions = {
   worktree?: string;
   encoding?: string;
   fileformat?: string;
+  emojify?: boolean;
   lnum?: number;
 };
 
@@ -68,7 +71,12 @@ export async function exec(
       fileencoding: options.encoding,
     },
   );
-  await buffer.append(denops, bufnr, content, {
-    lnum: options.lnum,
-  });
+  await buffer.append(
+    denops,
+    bufnr,
+    options.emojify ? content.map(emojify) : content,
+    {
+      lnum: options.lnum,
+    },
+  );
 }

--- a/denops/gin/command/log/command.ts
+++ b/denops/gin/command/log/command.ts
@@ -15,6 +15,7 @@ export type ExecOptions = {
   paths?: string[];
   flags?: Flags;
   opener?: string;
+  emojify?: boolean;
   cmdarg?: string;
   mods?: string;
   bang?: boolean;
@@ -41,6 +42,7 @@ export async function exec(
     params: {
       ...options.flags ?? {},
       commitish: options.commitish,
+      emojify: unnullish(options.emojify, (v) => v ? "" : undefined),
     },
     fragment: unnullish(paths, JSON.stringify),
   });

--- a/denops/gin/command/log/edit.ts
+++ b/denops/gin/command/log/edit.ts
@@ -48,9 +48,11 @@ export async function edit(
     flags: {
       ...params,
       commitish: undefined,
+      emojify: undefined,
     },
     encoding: opts.enc ?? opts.encoding,
     fileformat: opts.ff ?? opts.fileformat,
+    emojify: "emojify" in (params ?? {}),
   });
 }
 
@@ -61,6 +63,7 @@ export type ExecOptions = {
   flags?: Flags;
   encoding?: string;
   fileformat?: string;
+  emojify?: boolean;
 };
 
 export async function exec(
@@ -81,6 +84,7 @@ export async function exec(
     worktree: options.worktree,
     encoding: options.encoding,
     fileformat: options.fileformat,
+    emojify: options.emojify,
   });
   await buffer.ensure(denops, bufnr, async () => {
     await batch.batch(denops, async (denops) => {

--- a/denops/gin/command/log/main.ts
+++ b/denops/gin/command/log/main.ts
@@ -1,4 +1,5 @@
 import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
+import { unnullish } from "https://deno.land/x/unnullish@v1.0.1/unnullish.ts";
 import * as helper from "https://deno.land/x/denops_std@v5.0.1/helper/mod.ts";
 import { assert, is } from "https://deno.land/x/unknownutil@v3.0.0/mod.ts#^";
 import * as vars from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";
@@ -276,6 +277,7 @@ async function command(
   validateOpts(opts, [
     "worktree",
     "opener",
+    "emojify",
     ...builtinOpts,
   ]);
   validateFlags(flags, allowedFlags);
@@ -286,6 +288,7 @@ async function command(
     paths,
     flags,
     opener: opts.opener,
+    emojify: unnullish(opts.emojify, () => true),
     cmdarg: formatOpts(opts, builtinOpts).join(" "),
     mods,
     bang: bang === "!",

--- a/denops/gin/command/log/read.ts
+++ b/denops/gin/command/log/read.ts
@@ -36,6 +36,7 @@ export async function read(
     },
     encoding: opts.enc ?? opts.encoding,
     fileformat: opts.ff ?? opts.fileformat,
+    emojify: "emojify" in (params ?? {}),
   });
 }
 
@@ -46,6 +47,7 @@ export type ExecOptions = {
   flags?: Flags;
   encoding?: string;
   fileformat?: string;
+  emojify?: boolean;
 };
 
 export async function exec(
@@ -65,5 +67,6 @@ export async function exec(
     worktree: options.worktree,
     encoding: options.encoding,
     fileformat: options.fileformat,
+    emojify: options.emojify,
   });
 }

--- a/doc/gin.txt
+++ b/doc/gin.txt
@@ -121,6 +121,9 @@ COMMANDS					*gin-commands*
 		Displays the result in black and white without coloring.
 		Use this option when the resulting data is large and coloring
 		may cause performance problems.
+	
+	++emojify
+		Replace all ":emoji:" with emoji characters.
 
 	++processor={processor}
 		Specifies the processor program that will process the result.
@@ -269,6 +272,11 @@ COMMANDS					*gin-commands*
 							*:GinLog*
 :GinLog[!][&] [{++option}...] [{commitish}] [-- {pathspec}...]
 	Open a "gin-log" buffer to show a git log.
+	
+	The following options are valid as {++option}:
+
+	++emojify
+		Replace all ":emoji:" with emoji characters.
 
 	See |gin-commands-options| for common {++option}.
 		


### PR DESCRIPTION
![CleanShot 2023-06-23 at 04 49 32](https://github.com/lambdalisue/gin.vim/assets/546312/a717b5ef-6821-4ae0-a43e-0346e29133f5)
![CleanShot 2023-06-23 at 04 56 29](https://github.com/lambdalisue/gin.vim/assets/546312/241c5b06-ef25-4179-b1ee-840cec04ebf3)
