### PR TITLE
👍 support nested autocmd on QuitPre

### DIFF
--- a/autoload/gin/internal/proxy.vim
+++ b/autoload/gin/internal/proxy.vim
@@ -8,7 +8,7 @@ function gin#internal#proxy#init(waiter) abort
   command! -buffer -nargs=0 Cancel call s:cancel()
   augroup gin_internal_proxy_init
     autocmd! * <buffer>
-    autocmd QuitPre <buffer> ++once call s:confirm(expand('<afile>'))
+    autocmd QuitPre <buffer> ++nested ++once call s:confirm(expand('<afile>'))
   augroup END
 endfunction
 


### PR DESCRIPTION
Otherwise, `:wq` will not trigger triggger some events such as WinLeave, TabLeave, and so on
