### PR TITLE
:+1: Add `g:gin_proxy_apply_without_confirm` option to apply changes directly

### DIFF
--- a/autoload/gin/internal/proxy.vim
+++ b/autoload/gin/internal/proxy.vim
@@ -34,8 +34,13 @@ function s:reset() abort
 endfunction
 
 function s:confirm(bufnr) abort
+  if get(g:, 'gin_proxy_apply_without_confirm', 0)
+    call s:apply()
+    return
+  endif
   echohl Comment
   echo 'Hint: Use `:Apply` or `:Cancel` to apply or cancel changes directly'
+  echo 'Hint: Use `let g:gin_proxy_apply_without_confirm = 1` to apply changes without confirmation'
   echohl Title
   try
     let l:result = gin#internal#util#input(#{

--- a/autoload/gin/internal/proxy.vim
+++ b/autoload/gin/internal/proxy.vim
@@ -34,7 +34,6 @@ function s:reset() abort
 endfunction
 
 function s:confirm(bufnr) abort
-  let l:waiter = getbufvar(a:bufnr, 'gin_internal_proxy_waiter')
   echohl Comment
   echo 'Hint: Use `:Apply` or `:Cancel` to apply or cancel changes directly'
   echohl Title
@@ -47,7 +46,9 @@ function s:confirm(bufnr) abort
     echohl None
   endtry
   redraw
-  let l:success = l:result ==# '' || l:result =~? '^y\%[es]$'
-  call denops#request('gin', l:waiter, [l:success ? v:true : v:false])
-  bwipeout
+  if l:result ==# '' || l:result =~? '^y\%[es]$'
+    call s:apply()
+  else
+    call s:cancel()
+  endif
 endfunction

--- a/doc/gin.txt
+++ b/doc/gin.txt
@@ -84,6 +84,8 @@ It asks if users want to apply or cancel changes when |:quit| command is
 invoked. Answer "yes" to apply changes and others to cancel changes. Or use
 :Accept or :Cancel buffer local command to directly apply or cancel changes.
 
+Use |g:gin_proxy_apply_without_confirm| to apply changes without asking.
+
 Use |g:gin_proxy_editor_opener| to specify the opener command to open the
 buffer.
 
@@ -486,6 +488,11 @@ VARIABLES					*gin-variables*
 
 *g:gin_patch_disable_default_mappings*
 	Disable default mappings on buffers shown by |:GinPatch|.
+
+	Default: 0
+
+*g:gin_proxy_apply_without_confirm*
+	Apply changes without confirmation on proxy editors.
 
 	Default: 0
 

--- a/doc/gin.txt
+++ b/doc/gin.txt
@@ -80,6 +80,10 @@ guise.vim~
 It can live together with the plugins mentioned above because the environment
 variable names used are different.
 
+It asks if users want to apply or cancel changes when |:quit| command is
+invoked. Answer "yes" to apply changes and others to cancel changes. Or use
+:Accept or :Cancel buffer local command to directly apply or cancel changes.
+
 Use |g:gin_proxy_editor_opener| to specify the opener command to open the
 buffer.
 


### PR DESCRIPTION
Some people feel pain for confirmation dialog so.

Note that I gave up to support cancellation with `:q!` or `:wq!` while `v:cmdbang` is not set in `QuitPre` autocmd.