### PR TITLE
Cancel forcely the updated commit message with confirmation

### DIFF
--- a/autoload/gin/internal/proxy.vim
+++ b/autoload/gin/internal/proxy.vim
@@ -21,12 +21,6 @@ function s:apply() abort
 endfunction
 
 function s:cancel() abort
-  if &modified
-    let l:do = confirm('Cancel commit: message will be lost. Are you sure you want to cancel?', "&Yes\n&No")
-    if l:do != 1
-      return
-    endif
-  endif
   let l:waiter = b:gin_internal_proxy_waiter
   call s:reset()
   call denops#request('gin', l:waiter, [v:false])

--- a/autoload/gin/internal/proxy.vim
+++ b/autoload/gin/internal/proxy.vim
@@ -21,10 +21,16 @@ function s:apply() abort
 endfunction
 
 function s:cancel() abort
+  if &modified
+    let l:do = confirm('Cancel commit: message will be lost. Are you sure you want to cancel?', "&Yes\n&No")
+    if l:do != 1
+      return
+    endif
+  endif
   let l:waiter = b:gin_internal_proxy_waiter
   call s:reset()
   call denops#request('gin', l:waiter, [v:false])
-  bwipeout
+  bwipeout!
 endfunction
 
 function s:reset() abort


### PR DESCRIPTION
When I call `:Cancel` in a `COMMIT_MESSAGE` buffer, if the buffer has modified, I get an error "E89: No write since last change for buffer".
Even so the `:Cancel` is successed, but I cannot find it soon.
(I know that we should read the error careful.)
And if I call `:Cancel` again, and will get another error "Error invoking 'invoke' on channel 4".

So I propose:
- When the commit message has written, `:Cancel` confirms that it should be done.
- If it should be done, wipeout the buffer forcely.
