### PR TITLE
allow specifying regname for GinBrowse ++yank

### DIFF
--- a/denops/gin/command/browse/command.ts
+++ b/denops/gin/command/browse/command.ts
@@ -15,14 +15,14 @@ import { yank } from "../../util/yank.ts";
 
 export type ExecOptions = Omit<Options, "cwd" | "aliases"> & {
   worktree?: string;
-  yank?: boolean;
+  yank: string | boolean;
   noBrowser?: boolean;
 };
 
 export async function exec(
   denops: Denops,
   commitish: string,
-  options: ExecOptions = {},
+  options: ExecOptions = { yank: false },
 ): Promise<void> {
   const [verbose, aliases] = await batch.collect(denops, (denops) => [
     option.verbose.get(denops),
@@ -56,8 +56,12 @@ export async function exec(
     aliases,
   });
 
-  if (options.yank) {
-    await yank(denops, url.href);
+  if (options.yank !== false) {
+    await yank(
+      denops,
+      url.href,
+      options.yank === true ? undefined : options.yank,
+    );
   }
   if (options.noBrowser) {
     await denops.cmd("echomsg url", { url: url.href });

--- a/denops/gin/command/browse/command.ts
+++ b/denops/gin/command/browse/command.ts
@@ -15,14 +15,14 @@ import { yank } from "../../util/yank.ts";
 
 export type ExecOptions = Omit<Options, "cwd" | "aliases"> & {
   worktree?: string;
-  yank: string | boolean;
+  yank?: string | boolean;
   noBrowser?: boolean;
 };
 
 export async function exec(
   denops: Denops,
   commitish: string,
-  options: ExecOptions = { yank: false },
+  options: ExecOptions = {},
 ): Promise<void> {
   const [verbose, aliases] = await batch.collect(denops, (denops) => [
     option.verbose.get(denops),
@@ -56,7 +56,7 @@ export async function exec(
     aliases,
   });
 
-  if (options.yank !== false) {
+  if (options.yank != null && options.yank !== false) {
     await yank(
       denops,
       url.href,

--- a/denops/gin/command/browse/main.ts
+++ b/denops/gin/command/browse/main.ts
@@ -61,7 +61,7 @@ async function command(
   );
   await exec(denops, commitish ?? "HEAD", {
     worktree: opts.worktree,
-    yank: "yank" in opts,
+    yank: opts.yank === "" ? true : (opts.yank ?? false),
     noBrowser: ("n" in flags || "no-browser" in flags),
     remote: ensure(flags.remote, is.OneOf([is.Undefined, is.String]), {
       "message": "REMOTE in --remote={REMOTE} must be string",

--- a/denops/gin/util/yank.ts
+++ b/denops/gin/util/yank.ts
@@ -5,7 +5,8 @@ import { v } from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";
 export async function yank(
   denops: Denops,
   value: string,
+  reg?: string,
 ): Promise<void> {
-  const reg = await v.get(denops, "register");
+  reg = reg ?? await v.get(denops, "register");
   await fn.setreg(denops, reg, value);
 }

--- a/denops/gin/util/yank_test.ts
+++ b/denops/gin/util/yank_test.ts
@@ -10,4 +10,11 @@ test("all", "yank", async (denops, t) => {
       assertEquals(await denops.eval("getreg(v:register)"), "Hello world");
     },
   });
+  await t.step({
+    name: "sets the value to the named register a",
+    fn: async () => {
+      await yank(denops, "Hello world", "a");
+      assertEquals(await denops.eval("getreg('a')"), "Hello world");
+    },
+  });
 });

--- a/doc/gin.txt
+++ b/doc/gin.txt
@@ -177,8 +177,11 @@ COMMANDS					*gin-commands*
 
 	The following options are valid as {++option}:
 
-	++yank
+	++yank={regname}
 		Yank the URL to the clipboard.
+		{regname} is optional and defaults to |v:register|.
+		If non-empty string is given, the value is passed to the
+		{regname} argument of |setreg()|.
 
 	See |gin-commands-options| for common {++option}.
 


### PR DESCRIPTION
SSIA

- 👍 add optional reg argument to yank()
- 👍 allow specifying register to GinBrowser ++yank
- 🌿 test yank() with a explicit register
- 📝 document GinBrowse ++yank={regname}
