### PR TITLE
👍 add fixup actions to gin-log (fixup, amend, reword)

### DIFF
--- a/denops/gin/action/fixup.ts
+++ b/denops/gin/action/fixup.ts
@@ -1,0 +1,57 @@
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
+import * as batch from "https://deno.land/x/denops_std@v5.0.1/batch/mod.ts";
+import { alias, define, GatherCandidates, Range } from "./core.ts";
+
+export type Candidate = { commit: string };
+
+export async function init(
+  denops: Denops,
+  bufnr: number,
+  gatherCandidates: GatherCandidates<Candidate>,
+): Promise<void> {
+  await batch.batch(denops, async (denops) => {
+    await define(
+      denops,
+      bufnr,
+      "fixup:fixup",
+      (denops, bufnr, range) =>
+        doFixup(denops, bufnr, range, "fixup", gatherCandidates),
+    );
+    await define(
+      denops,
+      bufnr,
+      "fixup:amend",
+      (denops, bufnr, range) =>
+        doFixup(denops, bufnr, range, "amend", gatherCandidates),
+    );
+    await define(
+      denops,
+      bufnr,
+      "fixup:reword",
+      (denops, bufnr, range) =>
+        doFixup(denops, bufnr, range, "reword", gatherCandidates),
+    );
+    await alias(
+      denops,
+      bufnr,
+      "fixup",
+      "fixup:fixup",
+    );
+  });
+}
+
+async function doFixup(
+  denops: Denops,
+  bufnr: number,
+  range: Range,
+  kind: "fixup" | "amend" | "reword",
+  gatherCandidates: GatherCandidates<Candidate>,
+): Promise<void> {
+  const xs = await gatherCandidates(denops, bufnr, range);
+  const commit = xs.map((v) => v.commit).join("\n");
+  const target = kind === "fixup" ? commit : `${kind}:${commit}`;
+  // Do not block Vim so that users can edit commit message
+  denops
+    .dispatch("gin", "command", "", ["commit", `--fixup=${target}`])
+    .catch((e) => console.error(`failed to execute git commit: ${e}`));
+}

--- a/denops/gin/command/log/edit.ts
+++ b/denops/gin/command/log/edit.ts
@@ -20,6 +20,7 @@ import { init as initActionBrowse } from "../../action/browse.ts";
 import { init as initActionCherryPick } from "../../action/cherry_pick.ts";
 import { init as initActionCore, Range } from "../../action/core.ts";
 import { init as initActionEcho } from "../../action/echo.ts";
+import { init as initActionFixup } from "../../action/fixup.ts";
 import { init as initActionMerge } from "../../action/merge.ts";
 import { init as initActionRebase } from "../../action/rebase.ts";
 import { init as initActionReset } from "../../action/reset.ts";
@@ -94,6 +95,10 @@ export async function exec(
       await initActionBrowse(denops, bufnr, gatherCandidates);
       await initActionCherryPick(denops, bufnr, gatherCandidates);
       await initActionEcho(denops, bufnr, gatherCandidates);
+      await initActionFixup(denops, bufnr, async (denops, bufnr, range) => {
+        const xs = await gatherCandidates(denops, bufnr, range);
+        return xs.map((x) => ({ commit: x.commit }));
+      });
       await initActionMerge(denops, bufnr, gatherCandidates);
       await initActionRebase(denops, bufnr, gatherCandidates);
       await initActionReset(denops, bufnr, gatherCandidates);


### PR DESCRIPTION
adds

- `<Plug>(gin-action-fixup)`
- `<Plug>(gin-action-fixup:fixup)`
- `<Plug>(gin-action-fixup:amend)`
- `<Plug>(gin-action-fixup:reword)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new commands for advanced "fixup" operations within text buffers.
  - Enhanced version control interaction with new fixup and amend capabilities.

- **Improvements**
  - Streamlined the process of gathering and processing commit candidates for fixup actions.

- **Documentation**
  - Updated user instructions to accommodate new fixup and amend command workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->