### PR TITLE
:bug: Fix highlight alignment in emojified gin-log

### DIFF
--- a/denops/gin/command/buffer/edit.ts
+++ b/denops/gin/command/buffer/edit.ts
@@ -97,12 +97,12 @@ export async function exec(
   );
   const [trimmed, decorations] = await buildDecorationsFromAnsiEscapeCode(
     denops,
-    content,
+    options.emojify ? content.map(emojify) : content,
   );
   await buffer.replace(
     denops,
     bufnr,
-    options.emojify ? trimmed.map(emojify) : trimmed,
+    trimmed,
     {
       fileformat,
       fileencoding,


### PR DESCRIPTION
This fixes highlight alignment in emojified gin-log buffer.

Before fix: Misalignment of highlights in emojified text.

![image](https://github.com/lambdalisue/gin.vim/assets/60453380/b17c9b4f-b027-46bd-a306-c6485704cea6)

After fix: Correct alignment of highlights in emojified text.

![image](https://github.com/lambdalisue/gin.vim/assets/60453380/99392c73-912d-4277-85d0-9c3c510c14f1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced text processing to optionally include emojis based on user settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->