### PR TITLE
:bug: Fix timeout issue with `dd` command in patch and chaperon buffer

### DIFF
--- a/denops/gin/command/chaperon/command.ts
+++ b/denops/gin/command/chaperon/command.ts
@@ -154,6 +154,7 @@ async function initTheirs(
 ): Promise<void> {
   await buffer.ensure(denops, bufnr, async () => {
     await batch.batch(denops, async (denops) => {
+      const modes: mapping.Mode[] = ["n", "x"];
       await mapping.map(
         denops,
         "<Plug>(gin-diffput)",
@@ -161,6 +162,7 @@ async function initTheirs(
         {
           buffer: true,
           noremap: true,
+          mode: modes,
         },
       );
       if (!disableDefaultMappings) {
@@ -170,6 +172,7 @@ async function initTheirs(
           "<Plug>(gin-diffput)",
           {
             buffer: true,
+            mode: modes,
           },
         );
       }
@@ -189,6 +192,7 @@ async function initWorktree(
     const content = await fn.getbufline(denops, bufnr, 1, "$");
     await buffer.replace(denops, bufnr, stripConflicts(content));
     await batch.batch(denops, async (denops) => {
+      const modes: mapping.Mode[] = ["n", "x"];
       if (bufnrTheirs) {
         await mapping.map(
           denops,
@@ -197,6 +201,7 @@ async function initWorktree(
           {
             buffer: true,
             noremap: true,
+            mode: modes,
           },
         );
         await mapping.map(
@@ -205,6 +210,7 @@ async function initWorktree(
           "<Plug>(gin-diffget-l)",
           {
             buffer: true,
+            mode: modes,
           },
         );
         if (!disableDefaultMappings) {
@@ -214,6 +220,7 @@ async function initWorktree(
             "<Plug>(gin-diffget-l)",
             {
               buffer: true,
+              mode: modes,
             },
           );
           await mapping.map(
@@ -222,6 +229,7 @@ async function initWorktree(
             "<Plug>(gin-diffget)",
             {
               buffer: true,
+              mode: modes,
             },
           );
         }
@@ -234,6 +242,7 @@ async function initWorktree(
           {
             buffer: true,
             noremap: true,
+            mode: modes,
           },
         );
         await mapping.map(
@@ -242,6 +251,7 @@ async function initWorktree(
           "<Plug>(gin-diffget-r)",
           {
             buffer: true,
+            mode: modes,
           },
         );
         if (!disableDefaultMappings) {
@@ -251,6 +261,7 @@ async function initWorktree(
             "<Plug>(gin-diffget-r)",
             {
               buffer: true,
+              mode: modes,
             },
           );
           await mapping.map(
@@ -259,6 +270,7 @@ async function initWorktree(
             "<Plug>(gin-diffget)",
             {
               buffer: true,
+              mode: modes,
             },
           );
         }
@@ -275,6 +287,7 @@ async function initOurs(
 ): Promise<void> {
   await buffer.ensure(denops, bufnr, async () => {
     await batch.batch(denops, async (denops) => {
+      const modes: mapping.Mode[] = ["n", "x"];
       await mapping.map(
         denops,
         "<Plug>(gin-diffput)",
@@ -282,6 +295,7 @@ async function initOurs(
         {
           buffer: true,
           noremap: true,
+          mode: modes,
         },
       );
       if (!disableDefaultMappings) {
@@ -291,6 +305,7 @@ async function initOurs(
           "<Plug>(gin-diffput)",
           {
             buffer: true,
+            mode: modes,
           },
         );
       }

--- a/denops/gin/command/patch/command.ts
+++ b/denops/gin/command/patch/command.ts
@@ -128,6 +128,7 @@ async function initHead(
 ): Promise<void> {
   await buffer.ensure(denops, bufnr, async () => {
     await batch.batch(denops, async (denops) => {
+      const modes: mapping.Mode[] = ["n", "x"];
       await mapping.map(
         denops,
         "<Plug>(gin-diffput)",
@@ -135,6 +136,7 @@ async function initHead(
         {
           buffer: true,
           noremap: true,
+          mode: modes,
         },
       );
       if (!disableDefaultMappings) {
@@ -144,6 +146,7 @@ async function initHead(
           "<Plug>(gin-diffput)",
           {
             buffer: true,
+            mode: modes,
           },
         );
       }
@@ -160,6 +163,7 @@ async function initWorktree(
 ): Promise<void> {
   await buffer.ensure(denops, bufnr, async () => {
     await batch.batch(denops, async (denops) => {
+      const modes: mapping.Mode[] = ["n", "x"];
       await mapping.map(
         denops,
         "<Plug>(gin-diffput)",
@@ -167,6 +171,7 @@ async function initWorktree(
         {
           buffer: true,
           noremap: true,
+          mode: modes,
         },
       );
       await mapping.map(
@@ -176,6 +181,7 @@ async function initWorktree(
         {
           buffer: true,
           noremap: true,
+          mode: modes,
         },
       );
       if (!disableDefaultMappings) {
@@ -185,6 +191,7 @@ async function initWorktree(
           "<Plug>(gin-diffput)",
           {
             buffer: true,
+            mode: modes,
           },
         );
         await mapping.map(
@@ -193,6 +200,7 @@ async function initWorktree(
           "<Plug>(gin-diffget)",
           {
             buffer: true,
+            mode: modes,
           },
         );
       }
@@ -210,6 +218,7 @@ async function initIndex(
 ): Promise<void> {
   await buffer.ensure(denops, bufnr, async () => {
     await batch.batch(denops, async (denops) => {
+      const modes: mapping.Mode[] = ["n", "x"];
       if (bufnrHead !== -1) {
         await mapping.map(
           denops,
@@ -218,6 +227,7 @@ async function initIndex(
           {
             buffer: true,
             noremap: true,
+            mode: modes,
           },
         );
         await mapping.map(
@@ -226,6 +236,7 @@ async function initIndex(
           "<Plug>(gin-diffget-l)",
           {
             buffer: true,
+            mode: modes,
           },
         );
         if (!disableDefaultMappings) {
@@ -235,6 +246,7 @@ async function initIndex(
             "<Plug>(gin-diffget-l)",
             {
               buffer: true,
+              mode: modes,
             },
           );
           await mapping.map(
@@ -243,6 +255,7 @@ async function initIndex(
             "<Plug>(gin-diffget)",
             {
               buffer: true,
+              mode: modes,
             },
           );
         }
@@ -255,6 +268,7 @@ async function initIndex(
           {
             buffer: true,
             noremap: true,
+            mode: modes,
           },
         );
         await mapping.map(
@@ -264,6 +278,7 @@ async function initIndex(
           {
             buffer: true,
             noremap: true,
+            mode: modes,
           },
         );
         await mapping.map(
@@ -272,6 +287,7 @@ async function initIndex(
           "<Plug>(gin-diffget-r)",
           {
             buffer: true,
+            mode: modes,
           },
         );
         if (!disableDefaultMappings) {
@@ -281,6 +297,7 @@ async function initIndex(
             "<Plug>(gin-diffput)",
             {
               buffer: true,
+              mode: modes,
             },
           );
           await mapping.map(
@@ -289,6 +306,7 @@ async function initIndex(
             "<Plug>(gin-diffget-r)",
             {
               buffer: true,
+              mode: modes,
             },
           );
           await mapping.map(
@@ -297,6 +315,7 @@ async function initIndex(
             "<Plug>(gin-diffget)",
             {
               buffer: true,
+              mode: modes,
             },
           );
         }


### PR DESCRIPTION
- Before this fix, `dor`, `dol`, and `do` mappings were available in operator-pending mode in addition to normal and visual modes within the patch buffer. This caused the `dd` command to wait for a key sequence timeout.
- This commit removes the operator-pending mode mappings for `dor`, `dol`, and `do`, restricting them to only normal and visual modes. This change addresses the timeout issue when using the `dd` command in the patch buffer.