### PR TITLE
:bug: Fix don't set `nomodifiable` when call `GinEdit` with commitish

### DIFF
--- a/denops/gin/command/edit/edit.ts
+++ b/denops/gin/command/edit/edit.ts
@@ -78,6 +78,7 @@ export async function exec(
       await option.bufhidden.setLocal(denops, "unload");
       if (options.commitish) {
         await option.buftype.setLocal(denops, "nowrite");
+        await option.modifiable.setLocal(denops, false);
       } else {
         await option.buftype.setLocal(denops, "acwrite");
         await autocmd.group(


### PR DESCRIPTION
Following behavior to doc.
```
         If {commitish} is specified, it opens a buffer that shows content
         in the {commitish}. The buffer is not modifiable.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved stability by ensuring files are not modifiable under specific conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->