### PR TITLE
:bug: Fix invalid arguments in cherry-pick action

### DIFF
--- a/denops/gin/action/cherry_pick.ts
+++ b/denops/gin/action/cherry_pick.ts
@@ -48,7 +48,7 @@ async function doCherryPick(
   }
   await denops.dispatch("gin", "command", "", [
     "cherry-pick",
-    ...(mainline ? [] : ["--mainline", mainline]),
+    ...(mainline === "" ? [] : ["--mainline", mainline]),
     x.commit,
   ]);
 }


### PR DESCRIPTION
Invert if

Before:

"" => ["--mainline", ""]
"1" | "2" => []

Fixed:

"" => []
"1" | "2" => ["--mainline", "1" | "2"]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved cherry-pick functionality to handle scenarios where the `mainline` parameter is an empty string, ensuring smoother operation during code version control tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->