### PR TITLE
👍 avoid false-positive file changes from rebasing

### DIFF
--- a/denops/gin/action/fixup.ts
+++ b/denops/gin/action/fixup.ts
@@ -98,4 +98,7 @@ async function doFixupInstant(
     "--autosquash",
     `${commit}~`,
   ]);
+
+  // suppress false-positive detection of file changes
+  await denops.cmd("silent checktime");
 }

--- a/denops/gin/action/rebase.ts
+++ b/denops/gin/action/rebase.ts
@@ -43,6 +43,9 @@ async function doRebase(
     "rebase",
     x.commit,
   ]);
+
+  // suppress false-positive detection of file changes
+  await denops.cmd("silent checktime");
 }
 
 async function doRebaseInteractive(
@@ -65,5 +68,9 @@ async function doRebaseInteractive(
     x.commit,
   ]).catch(async (e) => {
     await helper.echoerr(denops, e.toString());
-  });
+  }).then(
+    // suppress false-positive detection of file changes
+    // NOTE: must be done on resolve because the rebase is not awaited
+    () => denops.cmd("silent checktime"),
+  );
 }


### PR DESCRIPTION
including fixup:instant, which internally does the rebase

Otherwise, following warning occurs on write:

> WARNING: The file has been changed since reading it!!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a command to reduce false-positive file change detections during certain operations, enhancing the user experience in file management tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->