### PR TITLE
revisit instant fixup by renaming and adding variants 

### DIFF
--- a/denops/gin/action/fixup.ts
+++ b/denops/gin/action/fixup.ts
@@ -25,7 +25,7 @@ export async function init(
         doFixup(denops, bufnr, range, gatherCandidates, true),
     );
 
-    const kinds: Array<"amend" | "reword"> = ["amend", "reword"];
+    const kinds = ["amend", "reword"] as const;
     for (const kind of kinds) {
       for (const instant of [true, false]) {
         await define(

--- a/denops/gin/action/fixup.ts
+++ b/denops/gin/action/fixup.ts
@@ -34,7 +34,7 @@ export async function init(
     await define(
       denops,
       bufnr,
-      "fixup:instant",
+      "fixup:instant-fixup",
       (denops, bufnr, range) =>
         doFixup(denops, bufnr, range, gatherCandidates, true),
     );


### PR DESCRIPTION
- Rename
    - `fixup:instant` -> `fixup:instant-fixup`
- Add
    - `fixup:instant-amend`
    - `fixup:instant-reword`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the fix-up functionality with a more flexible approach, including dynamic command definition and enhanced handling for instant squash actions.
	- Replaced specific functions with a more generalized approach.
	- Consolidated logic for instant squash into a separate function.
	- Updated the `doFixup` function to handle instant squash based on a new parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->