### PR TITLE
👍 do instant fixup without asking press ENTER

### DIFF
--- a/denops/gin/action/fixup.ts
+++ b/denops/gin/action/fixup.ts
@@ -63,6 +63,7 @@ async function doInstantSquash(denops: Denops, commit: string): Promise<void> {
     "--interactive",
     "--autostash",
     "--autosquash",
+    "--quiet",
     `${commit}~`,
   ]);
 
@@ -100,8 +101,12 @@ async function doFixupInteractive(
   const xs = await gatherCandidates(denops, bufnr, range);
   const commit = xs.map((v) => v.commit).join("\n");
   // Do not block Vim so that users can edit commit message
+  const args = ["commit", `--fixup=${kind}:${commit}`];
+  if (instant) {
+    args.push("--quiet");
+  }
   denops
-    .dispatch("gin", "command", "", ["commit", `--fixup=${kind}:${commit}`])
+    .dispatch("gin", "command", "", args)
     .then(
       instant ? () => doInstantSquash(denops, `${commit}~`) : undefined,
       (e) => console.error(`failed to execute git commit: ${e}`),


### PR DESCRIPTION
so that instant fixup becomes truly instant!

This PR adds `--quiet` flags to commit and rebase in order to suppress messages like below in Vim.

```
[branch xxxxxxxx] amend! hogehoge
Press ENTER or type command to continue
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the `doInstantSquash` and `doFixupInteractive` functions to suppress output during operations, improving user experience by making these processes quieter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->