### PR TITLE
Use repository root as the base path for worktree creation

### DIFF
--- a/denops/gin/git/finder.ts
+++ b/denops/gin/git/finder.ts
@@ -104,7 +104,7 @@ async function isWorktreeRoot(currentPath: string): Promise<boolean> {
   return false;
 }
 
-async function revParse(cwd: string, args: string[]): Promise<string> {
+export async function revParse(cwd: string, args: string[]): Promise<string> {
   const stdout = await execute(["rev-parse", ...args], { cwd });
   const output = decodeUtf8(stdout);
   return resolve(cwd, output.split(/\n/, 2)[0]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the process for creating new Git worktrees by automatically suggesting paths anchored to the repository's root directory.
- **Enhancements**
  - Worktree creation prompts now provide absolute paths based on the actual Git root, ensuring more accurate and consistent worktree locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->