### PR TITLE
fix: improve buffer cleanup and rename in gin-blame

### DIFF
--- a/denops/gin/command/blame/edit.ts
+++ b/denops/gin/command/blame/edit.ts
@@ -939,6 +939,9 @@ export async function switchToCommit(denops: Denops): Promise<void> {
       await fn.win_gotoid(denops, winidCurrent);
     }
   }
+
+  // Redraw to ensure display is updated after buffer/cursor changes
+  await denops.cmd("redraw");
 }
 
 /**
@@ -1077,4 +1080,7 @@ export async function navigateHistory(
   if (scheme === "ginblame") {
     await fn.win_gotoid(denops, winidCurrent);
   }
+
+  // Redraw to ensure display is updated after buffer/cursor changes
+  await denops.cmd("redraw");
 }


### PR DESCRIPTION
## Summary

- Use buffer numbers instead of buffer names for cleanup autocmd to prevent issues with special characters
- Replace `nvim_buf_set_name` with `:file` command for better Vim/Neovim compatibility  
- Remove unnecessary buffer switching logic after rename
- Store paired buffer numbers in buffer variables for reliable cleanup

## Test plan

- [ ] Test gin-blame with various file names including special characters
- [ ] Test buffer cleanup when closing blame buffers
- [ ] Verify compatibility with both Vim and Neovim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracking and cleanup of blame-related views so paired panes (navigation, detail, file) stay linked and are removed correctly after renames or closes.
  * Fixed issues where views could become stale or mismatched following buffer renames; state is now preserved across renames.
  * Ensured UI refresh after switching commits so the latest blame view is consistently displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->