### PR TITLE
feat: add highlight inheritance utility and improve blame divider styling

### DIFF
--- a/autoload/gin/internal/util.vim
+++ b/autoload/gin/internal/util.vim
@@ -6,6 +6,28 @@ function! gin#internal#util#debounce(expr, delay) abort
   let s:debounce_timers[a:expr] = timer_start(a:delay, { -> execute(a:expr) })
 endfunction
 
+" Inherit highlight attributes from a source group and apply additional attributes
+" @param target_group The name of the target highlight group
+" @param source_group The name of the source highlight group to inherit from
+" @param extra_attrs Dictionary with additional attributes (e.g., {'gui': 'strikethrough', 'cterm': 'strikethrough'})
+function! gin#internal#util#highlight_inherit(target_group, source_group, extra_attrs) abort
+  let source_hl = execute('highlight ' . a:source_group)
+  let guifg = matchstr(source_hl, 'guifg=\zs\S\+')
+  let guibg = matchstr(source_hl, 'guibg=\zs\S\+')
+  let ctermfg = matchstr(source_hl, 'ctermfg=\zs\S\+')
+  let ctermbg = matchstr(source_hl, 'ctermbg=\zs\S\+')
+
+  let hl_cmd = 'highlight ' . a:target_group
+  if has_key(a:extra_attrs, 'gui') | let hl_cmd .= ' gui=' . a:extra_attrs.gui | endif
+  if has_key(a:extra_attrs, 'cterm') | let hl_cmd .= ' cterm=' . a:extra_attrs.cterm | endif
+  if !empty(guifg) | let hl_cmd .= ' guifg=' . guifg | endif
+  if !empty(guibg) | let hl_cmd .= ' guibg=' . guibg | endif
+  if !empty(ctermfg) | let hl_cmd .= ' ctermfg=' . ctermfg | endif
+  if !empty(ctermbg) | let hl_cmd .= ' ctermbg=' . ctermbg | endif
+
+  execute hl_cmd
+endfunction
+
 function gin#internal#util#input(opts) abort
   return s:input(a:opts)
 endfunction

--- a/plugin/gin-blame.vim
+++ b/plugin/gin-blame.vim
@@ -3,12 +3,22 @@ if exists('g:loaded_gin_blame')
 endif
 let g:loaded_gin_blame = 1
 
+function! s:init_highlights() abort
+  call gin#internal#util#highlight_inherit(
+        \ 'GinBlameDivider',
+        \ 'Comment',
+        \ {'gui': 'strikethrough', 'cterm': 'strikethrough'}
+        \ )
+  sign define GinBlameDividerSign linehl=GinBlameDivider
+endfunction
+
 augroup gin_plugin_blame_internal
   autocmd!
   autocmd BufReadCmd ginblame://*
         \ call denops#request('gin', 'blame:edit', [bufnr(), expand('<amatch>')])
   autocmd BufReadCmd ginblamenav://*
         \ call denops#request('gin', 'blame:edit:nav', [bufnr(), expand('<amatch>')])
+  autocmd ColorScheme * call s:init_highlights()
 augroup END
 
 function! s:command(bang, mods, args) abort
@@ -20,5 +30,4 @@ endfunction
 
 command! -bang -bar -nargs=* GinBlame call s:command(<q-bang>, <q-mods>, [<f-args>])
 
-highlight GinBlameDivider gui=strikethrough cterm=strikethrough guifg=#505050 ctermfg=black
-sign define GinBlameDividerSign linehl=GinBlameDivider
+call s:init_highlights()


### PR DESCRIPTION
## Summary
- Add `gin#internal#util#highlight_inherit()` function for reusable highlight group inheritance
- Update `GinBlameDivider` to inherit from `Comment` group instead of using hardcoded colors
- Add `ColorScheme` autocmd to ensure highlights are reinitialized when color schemes change

## Benefits
- Improved color scheme compatibility: blame divider now adapts to any theme
- Reusable utility function for future highlight inheritance needs
- Cleaner separation of highlight initialization logic

## Test plan
- [ ] Verify `GinBlameDivider` inherits colors from `Comment` group
- [ ] Test with multiple color schemes to ensure proper reinitialization
- [ ] Confirm strikethrough styling is applied correctly in both GUI and terminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced highlight management for git blame display to properly adapt to color scheme changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->