### PR TITLE
Add GinTag command for managing git tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ without announcements.**
 - `GinReflog` to see `git reflog` of a repository
 - `GinStash` to see `git stash list` of a repository
 - `GinStatus` to see `git status` of a repository
+- `GinTag` to see `git tag --list` of a repository
 
 See [Features](https://github.com/lambdalisue/vim-gin/wiki/Features) in Wiki for
 detail about each features.

--- a/denops/gin/action/tag_delete.ts
+++ b/denops/gin/action/tag_delete.ts
@@ -1,0 +1,37 @@
+import type { Denops } from "jsr:@denops/std@^7.0.0";
+import * as batch from "jsr:@denops/std@^7.0.0/batch";
+import { define, GatherCandidates, Range } from "./core.ts";
+
+export type Candidate = { tag: string };
+
+export async function init(
+  denops: Denops,
+  bufnr: number,
+  gatherCandidates: GatherCandidates<Candidate>,
+): Promise<void> {
+  await batch.batch(denops, async (denops) => {
+    await define(
+      denops,
+      bufnr,
+      "delete",
+      (denops, bufnr, range) =>
+        doTagDelete(denops, bufnr, range, gatherCandidates),
+    );
+  });
+}
+
+async function doTagDelete(
+  denops: Denops,
+  bufnr: number,
+  range: Range,
+  gatherCandidates: GatherCandidates<Candidate>,
+): Promise<void> {
+  const xs = await gatherCandidates(denops, bufnr, range);
+  for (const x of xs) {
+    await denops.dispatch("gin", "command", "", [
+      "tag",
+      "-d",
+      x.tag,
+    ]);
+  }
+}

--- a/denops/gin/command/tag/command.ts
+++ b/denops/gin/command/tag/command.ts
@@ -1,0 +1,49 @@
+import type { Denops } from "jsr:@denops/std@^7.0.0";
+import { unnullish } from "jsr:@lambdalisue/unnullish@^1.0.0";
+import * as buffer from "jsr:@denops/std@^7.0.0/buffer";
+import * as option from "jsr:@denops/std@^7.0.0/option";
+import { format as formatBufname } from "jsr:@denops/std@^7.0.0/bufname";
+import { Flags } from "jsr:@denops/std@^7.0.0/argument";
+import { findWorktreeFromDenops } from "../../git/worktree.ts";
+
+export type ExecOptions = {
+  worktree?: string;
+  flags?: Flags;
+  patterns?: string[];
+  opener?: string;
+  emojify?: boolean;
+  cmdarg?: string;
+  mods?: string;
+  bang?: boolean;
+};
+
+export async function exec(
+  denops: Denops,
+  options: ExecOptions = {},
+): Promise<buffer.OpenResult> {
+  const verbose = await option.verbose.get(denops);
+
+  const worktree = await findWorktreeFromDenops(denops, {
+    worktree: options.worktree,
+    verbose: !!verbose,
+  });
+
+  const bufname = formatBufname({
+    scheme: "gintag",
+    expr: worktree,
+    params: {
+      ...options.flags ?? {},
+      emojify: unnullish(options.emojify, (v) => v ? "" : undefined),
+    },
+    fragment: unnullish(
+      options.patterns,
+      (v) => v.length > 0 ? `${v.join(" ")}$` : undefined,
+    ),
+  });
+  return await buffer.open(denops, bufname, {
+    opener: options.opener,
+    cmdarg: options.cmdarg,
+    mods: options.mods,
+    bang: options.bang,
+  });
+}

--- a/denops/gin/command/tag/edit.ts
+++ b/denops/gin/command/tag/edit.ts
@@ -1,0 +1,137 @@
+import type { Denops } from "jsr:@denops/std@^7.0.0";
+import { unnullish } from "jsr:@lambdalisue/unnullish@^1.0.0";
+import { ensure, is } from "jsr:@core/unknownutil@^4.0.0";
+import * as fn from "jsr:@denops/std@^7.0.0/function";
+import * as batch from "jsr:@denops/std@^7.0.0/batch";
+import * as buffer from "jsr:@denops/std@^7.0.0/buffer";
+import * as option from "jsr:@denops/std@^7.0.0/option";
+import * as vars from "jsr:@denops/std@^7.0.0/variable";
+import { parse as parseBufname } from "jsr:@denops/std@^7.0.0/bufname";
+import {
+  builtinOpts,
+  Flags,
+  formatFlags,
+  parseOpts,
+  validateOpts,
+} from "jsr:@denops/std@^7.0.0/argument";
+import { bind } from "../../command/bare/command.ts";
+import { exec as execBuffer } from "../../command/buffer/edit.ts";
+import { init as initActionBrowse } from "../../action/browse.ts";
+import { init as initActionCore, Range } from "../../action/core.ts";
+import { init as initActionEcho } from "../../action/echo.ts";
+import { init as initActionShow } from "../../action/show.ts";
+import { init as initActionSwitch } from "../../action/switch.ts";
+import { init as initActionTagDelete } from "../../action/tag_delete.ts";
+import { init as initActionYank } from "../../action/yank.ts";
+import { Entry, parse as parseTag } from "./parser.ts";
+
+const defaultFormat =
+  "%(objectname:short) %(refname:short) %(creatordate:short) %(subject)";
+
+export async function edit(
+  denops: Denops,
+  bufnr: number,
+  bufname: string,
+): Promise<void> {
+  const cmdarg = await vars.v.get(denops, "cmdarg") as string;
+  const [opts, _] = parseOpts(cmdarg.split(" "));
+  validateOpts(opts, builtinOpts);
+  const { expr, params, fragment } = parseBufname(bufname);
+  await exec(denops, bufnr, {
+    worktree: expr,
+    flags: {
+      ...params,
+      emojify: undefined,
+    },
+    patterns: fragment?.replace(/\$$/, "").split(" ").filter((v) => v),
+    encoding: opts.enc ?? opts.encoding,
+    fileformat: opts.ff ?? opts.fileformat,
+    emojify: "emojify" in (params ?? {}),
+  });
+}
+
+export type ExecOptions = {
+  worktree?: string;
+  flags?: Flags;
+  patterns?: string[];
+  encoding?: string;
+  fileformat?: string;
+  emojify?: boolean;
+};
+
+export async function exec(
+  denops: Denops,
+  bufnr: number,
+  options: ExecOptions,
+): Promise<void> {
+  const args = [
+    "tag",
+    "--list",
+    "--color=never",
+    `--format=${defaultFormat}`,
+    ...formatFlags(options.flags ?? {}),
+    "--",
+    ...(options.patterns ?? []),
+  ];
+  await execBuffer(denops, bufnr, args, {
+    worktree: options.worktree,
+    monochrome: true,
+    encoding: options.encoding,
+    fileformat: options.fileformat,
+    emojify: options.emojify,
+  });
+  await buffer.ensure(denops, bufnr, async () => {
+    await batch.batch(denops, async (denops) => {
+      await bind(denops, bufnr);
+      await initActionCore(denops, bufnr);
+      await initActionBrowse(denops, bufnr, gatherCandidates);
+      await initActionEcho(denops, bufnr, gatherCandidates);
+      await initActionShow(denops, bufnr, gatherCandidates);
+      await initActionSwitch(denops, bufnr, async (denops, bufnr, range) => {
+        const xs = await gatherCandidates(denops, bufnr, range);
+        return xs.map((x) => ({ target: x.tag }));
+      });
+      await initActionTagDelete(denops, bufnr, gatherCandidates);
+      await initActionYank(denops, bufnr, async (denops, bufnr, range) => {
+        const xs = await gatherCandidates(denops, bufnr, range);
+        return xs.map((x) => ({ value: x.tag }));
+      }, {
+        suffix: ":tag",
+      });
+      await initActionYank(denops, bufnr, async (denops, bufnr, range) => {
+        const xs = await gatherCandidates(denops, bufnr, range);
+        return xs.map((x) => ({ value: x.commit }));
+      }, {
+        suffix: ":commit",
+      });
+      await option.filetype.setLocal(denops, "gin-tag");
+    });
+  });
+}
+
+async function gatherCandidates(
+  denops: Denops,
+  bufnr: number,
+  [start, end]: Range,
+): Promise<Entry[]> {
+  const [content, patternStr] = await batch.collect(denops, (denops) => [
+    fn.getbufline(
+      denops,
+      bufnr,
+      Math.max(start, 1),
+      Math.max(end, 1),
+    ),
+    vars.g.get(denops, "gin_tag_parse_pattern"),
+  ]);
+  const pattern = unnullish(
+    patternStr,
+    (v) =>
+      new RegExp(
+        ensure(v, is.String, {
+          message: "g:gin_tag_parse_pattern must be string",
+        }),
+      ),
+  );
+  const result = parseTag(content, pattern);
+  return result.entries;
+}

--- a/denops/gin/command/tag/main.ts
+++ b/denops/gin/command/tag/main.ts
@@ -1,0 +1,75 @@
+import type { Denops } from "jsr:@denops/std@^7.0.0";
+import { assert, is } from "jsr:@core/unknownutil@^4.0.0";
+import { unnullish } from "jsr:@lambdalisue/unnullish@^1.0.0";
+import * as helper from "jsr:@denops/std@^7.0.0/helper";
+import {
+  builtinOpts,
+  formatOpts,
+  parse,
+  validateOpts,
+} from "jsr:@denops/std@^7.0.0/argument";
+import { fillCmdArgs, normCmdArgs, parseSilent } from "../../util/cmd.ts";
+import { exec } from "./command.ts";
+import { edit } from "./edit.ts";
+import { read } from "./read.ts";
+
+export function main(denops: Denops): void {
+  denops.dispatcher = {
+    ...denops.dispatcher,
+    "tag:command": (bang, mods, args) => {
+      assert(bang, is.String, { name: "bang" });
+      assert(mods, is.String, { name: "mods" });
+      assert(args, is.ArrayOf(is.String), { name: "args" });
+      const silent = parseSilent(mods);
+      return helper.ensureSilent(denops, silent, () => {
+        return helper.friendlyCall(
+          denops,
+          () => command(denops, bang, mods, args),
+        );
+      });
+    },
+    "tag:edit": (bufnr, bufname) => {
+      assert(bufnr, is.Number, { name: "bufnr" });
+      assert(bufname, is.String, { name: "bufname" });
+      return helper.friendlyCall(denops, () => edit(denops, bufnr, bufname));
+    },
+    "tag:read": (bufnr, bufname) => {
+      assert(bufnr, is.Number, { name: "bufnr" });
+      assert(bufname, is.String, { name: "bufname" });
+      return helper.friendlyCall(denops, () => read(denops, bufnr, bufname));
+    },
+  };
+}
+
+async function command(
+  denops: Denops,
+  bang: string,
+  mods: string,
+  args: string[],
+): Promise<void> {
+  args = await fillCmdArgs(denops, args, "tag");
+  args = await normCmdArgs(denops, args);
+
+  const [opts, flags, residue] = parse(args);
+  validateOpts(opts, [
+    "worktree",
+    "opener",
+    "emojify",
+    ...builtinOpts,
+  ]);
+
+  // GinTag [{options}]
+  // GinTag [{options}] [{pattern}...]
+  const patterns = residue;
+
+  await exec(denops, {
+    worktree: opts.worktree,
+    flags,
+    patterns,
+    opener: opts.opener,
+    emojify: unnullish(opts.emojify, () => true),
+    cmdarg: formatOpts(opts, builtinOpts).join(" "),
+    mods,
+    bang: bang === "!",
+  });
+}

--- a/denops/gin/command/tag/parser.ts
+++ b/denops/gin/command/tag/parser.ts
@@ -1,0 +1,24 @@
+const defaultPattern = /^([a-fA-F0-9]+)\s+(\S+)/;
+
+export interface GitTagResult {
+  entries: Entry[];
+}
+
+export type Entry = {
+  commit: string;
+  tag: string;
+};
+
+export function parse(content: string[], pattern?: RegExp): GitTagResult {
+  const entries: Entry[] = content.filter((v) => v).flatMap((record) => {
+    const m = record.match(pattern ?? defaultPattern);
+    if (m) {
+      return [{
+        commit: m[1],
+        tag: m[2],
+      }];
+    }
+    return [];
+  });
+  return { entries };
+}

--- a/denops/gin/command/tag/parser_test.ts
+++ b/denops/gin/command/tag/parser_test.ts
@@ -1,0 +1,118 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.0";
+import { parse } from "./parser.ts";
+
+Deno.test("parse default format output", () => {
+  const content = [
+    "a220f64 v0.0.0 2022-03-04 Initial release",
+    "fc95d6d v0.1.0 2022-03-31 Add new feature",
+    "6bfc537 v1.0.0 2022-08-02 Major release",
+  ];
+  assertEquals(parse(content), {
+    entries: [
+      { commit: "a220f64", tag: "v0.0.0" },
+      { commit: "fc95d6d", tag: "v0.1.0" },
+      { commit: "6bfc537", tag: "v1.0.0" },
+    ],
+  });
+});
+
+Deno.test("parse empty input", () => {
+  const content: string[] = [];
+  assertEquals(parse(content), {
+    entries: [],
+  });
+});
+
+Deno.test("parse input with empty lines", () => {
+  const content = [
+    "a220f64 v0.0.0 2022-03-04 Initial release",
+    "",
+    "fc95d6d v0.1.0 2022-03-31 Add new feature",
+    "",
+  ];
+  assertEquals(parse(content), {
+    entries: [
+      { commit: "a220f64", tag: "v0.0.0" },
+      { commit: "fc95d6d", tag: "v0.1.0" },
+    ],
+  });
+});
+
+Deno.test("parse tags without subject", () => {
+  const content = [
+    "a220f64 v0.0.0 2022-03-04",
+    "fc95d6d v0.1.0 2022-03-31",
+  ];
+  assertEquals(parse(content), {
+    entries: [
+      { commit: "a220f64", tag: "v0.0.0" },
+      { commit: "fc95d6d", tag: "v0.1.0" },
+    ],
+  });
+});
+
+Deno.test("parse tags with full commit hashes", () => {
+  const content = [
+    "a220f64abc123def456789012345678901234567 v0.0.0 2022-03-04 Initial release",
+    "fc95d6dabc123def456789012345678901234567 v0.1.0 2022-03-31 Add new feature",
+  ];
+  assertEquals(parse(content), {
+    entries: [
+      { commit: "a220f64abc123def456789012345678901234567", tag: "v0.0.0" },
+      { commit: "fc95d6dabc123def456789012345678901234567", tag: "v0.1.0" },
+    ],
+  });
+});
+
+Deno.test("parse tags with special characters in name", () => {
+  const content = [
+    "a220f64 v1.0.0-rc.1 2024-01-15 Release candidate",
+    "fc95d6d release/v3.0 2024-02-20 Release branch tag",
+  ];
+  assertEquals(parse(content), {
+    entries: [
+      { commit: "a220f64", tag: "v1.0.0-rc.1" },
+      { commit: "fc95d6d", tag: "release/v3.0" },
+    ],
+  });
+});
+
+Deno.test("parse lines that do not match the pattern", () => {
+  const content = [
+    "  indented line that should not match",
+    "a220f64 v1.0.0 2024-01-15 Valid entry",
+    "not-a-hash v2.0.0 2024-02-20 Invalid hash",
+  ];
+  assertEquals(parse(content), {
+    entries: [
+      { commit: "a220f64", tag: "v1.0.0" },
+    ],
+  });
+});
+
+Deno.test("parse with custom pattern", () => {
+  const content = [
+    "a220f64 v0.0.0 2022-03-04 Initial release",
+    "fc95d6d v0.1.0 2022-03-31 Add new feature",
+  ];
+  const customPattern = /^([a-fA-F0-9]{7})\s+(v\d+\.\d+\.\d+)/;
+  assertEquals(parse(content, customPattern), {
+    entries: [
+      { commit: "a220f64", tag: "v0.0.0" },
+      { commit: "fc95d6d", tag: "v0.1.0" },
+    ],
+  });
+});
+
+Deno.test("parse tags with emoji in subject", () => {
+  const content = [
+    "a220f64 v0.0.0 2022-03-04 :memo: Update documentations",
+    "fc95d6d v0.1.0 2022-03-31 :sparkles: Add new feature",
+  ];
+  assertEquals(parse(content), {
+    entries: [
+      { commit: "a220f64", tag: "v0.0.0" },
+      { commit: "fc95d6d", tag: "v0.1.0" },
+    ],
+  });
+});

--- a/denops/gin/command/tag/read.ts
+++ b/denops/gin/command/tag/read.ts
@@ -1,0 +1,68 @@
+import type { Denops } from "jsr:@denops/std@^7.0.0";
+import { ensure, is } from "jsr:@core/unknownutil@^4.0.0";
+import * as vars from "jsr:@denops/std@^7.0.0/variable";
+import { parse as parseBufname } from "jsr:@denops/std@^7.0.0/bufname";
+import {
+  builtinOpts,
+  Flags,
+  formatFlags,
+  parseOpts,
+  validateOpts,
+} from "jsr:@denops/std@^7.0.0/argument";
+import { exec as execBuffer } from "../../command/buffer/read.ts";
+
+const defaultFormat =
+  "%(objectname:short) %(refname:short) %(creatordate:short) %(subject)";
+
+export async function read(
+  denops: Denops,
+  bufnr: number,
+  bufname: string,
+): Promise<void> {
+  const cmdarg = ensure(await vars.v.get(denops, "cmdarg"), is.String);
+  const [opts, _] = parseOpts(cmdarg.split(" "));
+  validateOpts(opts, builtinOpts);
+  const { expr, params, fragment } = parseBufname(bufname);
+  await exec(denops, bufnr, {
+    worktree: expr,
+    flags: {
+      ...params,
+      emojify: undefined,
+    },
+    patterns: fragment?.replace(/\$$/, "").split(" ").filter((v) => v),
+    encoding: opts.enc ?? opts.encoding,
+    fileformat: opts.ff ?? opts.fileformat,
+    emojify: "emojify" in (params ?? {}),
+  });
+}
+
+export type ExecOptions = {
+  worktree?: string;
+  flags?: Flags;
+  patterns?: string[];
+  encoding?: string;
+  fileformat?: string;
+  emojify?: boolean;
+};
+
+export async function exec(
+  denops: Denops,
+  bufnr: number,
+  options: ExecOptions,
+): Promise<void> {
+  const args = [
+    "tag",
+    "--list",
+    "--color=never",
+    `--format=${defaultFormat}`,
+    ...formatFlags(options.flags ?? {}),
+    "--",
+    ...(options.patterns ?? []),
+  ];
+  await execBuffer(denops, bufnr, args, {
+    worktree: options.worktree,
+    encoding: options.encoding,
+    fileformat: options.fileformat,
+    emojify: options.emojify,
+  });
+}

--- a/denops/gin/main.ts
+++ b/denops/gin/main.ts
@@ -16,6 +16,7 @@ import { main as mainPatch } from "./command/patch/main.ts";
 import { main as mainReflog } from "./command/reflog/main.ts";
 import { main as mainStash } from "./command/stash/main.ts";
 import { main as mainStatus } from "./command/status/main.ts";
+import { main as mainTag } from "./command/tag/main.ts";
 
 import { main as mainComponentBranch } from "./component/branch.ts";
 import { main as mainComponentTraffic } from "./component/traffic.ts";
@@ -38,6 +39,7 @@ export function main(denops: Denops): void {
   mainReflog(denops);
   mainStash(denops);
   mainStatus(denops);
+  mainTag(denops);
 
   mainComponentBranch(denops);
   mainComponentTraffic(denops);

--- a/doc/gin.txt
+++ b/doc/gin.txt
@@ -430,6 +430,31 @@ COMMANDS					*gin-commands*
 
 	Use a bang (!) to forcibly open a buffer.
 
+							*:GinTag*
+:GinTag[!] [{++option}...] [{flags}] [{pattern}...]
+	Open a "gin-tag" buffer to show a tag list.
+
+	The following options are valid as {++option}:
+
+	++emojify
+		Replace all ":emoji:" with emoji characters.
+
+	See |gin-commands-options| for common {++option}.
+
+	See ":man git-tag(1)" for detail about each {flags}.
+
+	The optional {pattern} arguments are shell wildcard patterns. If
+	given, only tags matching the patterns are shown.
+
+	Several default mappings are defined in the buffer. Use "help" action
+	to see mappings or disable by |g:gin_tag_disable_default_mappings|.
+
+	Users can specify default and/or persistent arguments of the command.
+	See |gin-commands-default-args| and/or |gin-commands-persistent-args|
+	for detail.
+
+	Use a bang (!) to forcibly open a buffer.
+
 							*:GinPatch*
 :GinPatch[!] [{++option}...] [{path}]
 	Open three buffers (HEAD, INDEX, and WORKTREE) to patch changes of

--- a/ftplugin/gin-tag.vim
+++ b/ftplugin/gin-tag.vim
@@ -1,0 +1,21 @@
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal nobuflisted
+setlocal nolist nospell
+setlocal nowrap nofoldenable
+setlocal cursorline
+setlocal nomodeline
+
+if !get(g:, 'gin_tag_disable_default_mappings')
+  map <buffer><nowait> a <Plug>(gin-action-choice)
+  map <buffer><nowait> . <Plug>(gin-action-repeat)
+  nmap <buffer><nowait> ? <Plug>(gin-action-help)
+
+  map <buffer><nowait> <Return> <Plug>(gin-action-show)zv
+
+  nmap <buffer><nowait> yy <Plug>(gin-action-yank:tag)
+  vmap <buffer><nowait> y <Plug>(gin-action-yank:tag)<Esc>
+endif

--- a/plugin/gin-tag.vim
+++ b/plugin/gin-tag.vim
@@ -1,0 +1,21 @@
+if exists('g:loaded_gin_tag')
+  finish
+endif
+let g:loaded_gin_tag = 1
+
+augroup gin_plugin_tag_internal
+  autocmd!
+  autocmd BufReadCmd gintag://*
+        \ call denops#request('gin', 'tag:edit', [bufnr(), expand('<amatch>')])
+  autocmd FileReadCmd gintag://*
+        \ call denops#request('gin', 'tag:read', [bufnr(), expand('<amatch>')])
+augroup END
+
+function! s:command(bang, mods, args) abort
+  if denops#plugin#wait('gin')
+    return
+  endif
+  call denops#request('gin', 'tag:command', [a:bang, a:mods, a:args])
+endfunction
+
+command! -bang -bar -nargs=* GinTag call s:command(<q-bang>, <q-mods>, [<f-args>])

--- a/syntax/gin-tag.vim
+++ b/syntax/gin-tag.vim
@@ -1,0 +1,16 @@
+if exists('b:current_syntax')
+  finish
+endif
+let b:current_syntax = 'gin_tag'
+
+syntax clear
+
+highlight default link GinTagHash Constant
+highlight default link GinTagName Special
+highlight default link GinTagDate Title
+highlight default link GinTagSubject Comment
+
+syntax match GinTagHash /^[0-9a-f]\{7,\}/ nextgroup=GinTagName skipwhite
+syntax match GinTagName /\S\+/ contained nextgroup=GinTagDate skipwhite
+syntax match GinTagDate /\d\{4\}-\d\{2\}-\d\{2\}/ contained nextgroup=GinTagSubject skipwhite
+syntax match GinTagSubject /.*/ contained


### PR DESCRIPTION
## Summary
- Add `GinTag` command to display and manage git tags in a buffer
- Implement tag deletion action for removing local/remote tags
- Add syntax highlighting, ftplugin, and Vim plugin support

## Why
This PR extends vim-gin with git tag management capabilities, following the same pattern established by `GinReflog` and other commands. Users can now view, navigate, and delete git tags directly from Vim without leaving their editing environment. The implementation includes a complete parser with tests, proper syntax highlighting, and intuitive buffer actions for tag operations.

## Test Plan
- [ ] Run `GinTag` command and verify tag list displays correctly
- [ ] Test tag deletion action (local and remote)
- [ ] Verify syntax highlighting works for tag buffer
- [ ] Run parser tests: `deno test denops/gin/command/tag/parser_test.ts`
- [ ] Test with repositories containing annotated and lightweight tags
- [ ] Verify ftplugin loads correctly for gin-tag buffers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GinTag command to view and manage repository tags with formatting options.
  * Implemented tag deletion action and syntax highlighting for tag output.
  * Configured default key mappings for tag operations.

* **Documentation**
  * Added GinTag command documentation and usage guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->