### PR TITLE
Add commit:split action and rebase progress indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ without announcements.**
 
 - Proxy the prompts/editor used by git commands to Vim
 - Components to show information on `statusline` and/or `tabline`
+  - Branch, traffic, worktree, and rebase progress indicators
 - `Gin` to call a raw git command and echo the result
 - `GinBuffer` to call a raw git command and open a result buffer
 - `GinBranch` to see `git branch` of a repository
@@ -27,6 +28,7 @@ without announcements.**
 - `GinReflog` to see `git reflog` of a repository
 - `GinStash` to see `git stash list` of a repository
 - `GinStatus` to see `git status` of a repository
+  - Shows rebase progress header when rebase is in progress
 - `GinTag` to see `git tag --list` of a repository
 
 See [Features](https://github.com/lambdalisue/vim-gin/wiki/Features) in Wiki for

--- a/README.md
+++ b/README.md
@@ -24,11 +24,14 @@ without announcements.**
 - `GinDiff` to see `git diff` of a file
 - `GinEdit` to see `git show` of a file
 - `GinLog` to see `git log` of a repository/file
+  - `commit:split` action to split commits via interactive rebase
 - `GinPatch` to stage changes partially (like `git add -p`)
 - `GinReflog` to see `git reflog` of a repository
+  - `commit:split` action to split commits via interactive rebase
 - `GinStash` to see `git stash list` of a repository
 - `GinStatus` to see `git status` of a repository
   - Shows rebase progress header when rebase is in progress
+  - `commit:split` action to split commits via interactive rebase
 - `GinTag` to see `git tag --list` of a repository
 
 See [Features](https://github.com/lambdalisue/vim-gin/wiki/Features) in Wiki for

--- a/autoload/gin/component/rebase.vim
+++ b/autoload/gin/component/rebase.vim
@@ -1,0 +1,11 @@
+function! gin#component#rebase#ascii() abort
+  let component = 'component:rebase:ascii'
+  call gin#internal#component#init(component)
+  return gin#internal#component#get(component)
+endfunction
+
+function! gin#component#rebase#unicode() abort
+  let component = 'component:rebase:unicode'
+  call gin#internal#component#init(component)
+  return gin#internal#component#get(component)
+endfunction

--- a/denops/gin/action/commit_split.ts
+++ b/denops/gin/action/commit_split.ts
@@ -1,0 +1,241 @@
+import type { Denops } from "jsr:@denops/std@^7.0.0";
+import * as batch from "jsr:@denops/std@^7.0.0/batch";
+import * as fn from "jsr:@denops/std@^7.0.0/function";
+import * as helper from "jsr:@denops/std@^7.0.0/helper";
+import * as path from "jsr:@std/path@^1.0.0";
+import { alias, define, GatherCandidates, Range } from "./core.ts";
+import { execute } from "../git/process.ts";
+import { findWorktreeFromDenops } from "../git/worktree.ts";
+import { findGitdir } from "../git/finder.ts";
+import { isRebaseInProgress } from "../git/rebase.ts";
+import { decodeUtf8 } from "../util/text.ts";
+
+const BACKUP_FILENAME = "GIN_SPLIT_ORIGINAL_TEMPLATE";
+const SPLIT_MSG_FILENAME = "GIN_SPLIT_MSG";
+
+export type Candidate = { commit: string };
+
+/**
+ * Clean up leftover commit.template override from a previous commit:split.
+ * Safe to call at any time - no-op if no cleanup is needed.
+ */
+export async function tryCleanupSplitTemplate(
+  worktree: string,
+): Promise<void> {
+  const gitdir = await findGitdir(worktree);
+  const backupPath = path.join(gitdir, BACKUP_FILENAME);
+
+  // Check if backup marker file exists
+  try {
+    await Deno.stat(backupPath);
+  } catch {
+    return;
+  }
+
+  // Only clean up when rebase is no longer in progress
+  if (await isRebaseInProgress(worktree)) {
+    return;
+  }
+
+  // Restore original commit.template
+  try {
+    const backup = (await Deno.readTextFile(backupPath)).trim();
+    if (backup) {
+      await execute(
+        ["config", "--local", "commit.template", backup],
+        { cwd: worktree },
+      );
+    } else {
+      try {
+        await execute(
+          ["config", "--local", "--unset", "commit.template"],
+          { cwd: worktree },
+        );
+      } catch {
+        // Already unset, ignore
+      }
+    }
+  } catch {
+    try {
+      await execute(
+        ["config", "--local", "--unset", "commit.template"],
+        { cwd: worktree },
+      );
+    } catch {
+      // Already unset, ignore
+    }
+  }
+
+  // Remove temporary files
+  const splitMsgPath = path.join(gitdir, SPLIT_MSG_FILENAME);
+  await Deno.remove(backupPath).catch(() => {});
+  await Deno.remove(splitMsgPath).catch(() => {});
+}
+
+export async function init(
+  denops: Denops,
+  bufnr: number,
+  gatherCandidates: GatherCandidates<Candidate>,
+): Promise<void> {
+  const openers = ["edit", "split", "vsplit", "tabedit"];
+  await batch.batch(denops, async (denops) => {
+    for (const opener of openers) {
+      await define(
+        denops,
+        bufnr,
+        `commit:split:${opener}`,
+        (denops, bufnr, range) =>
+          doCommitSplit(denops, bufnr, range, opener, gatherCandidates),
+      );
+    }
+    await alias(denops, bufnr, "commit:split", "commit:split:edit");
+  });
+}
+
+async function doCommitSplit(
+  denops: Denops,
+  bufnr: number,
+  range: Range,
+  opener: string,
+  gatherCandidates: GatherCandidates<Candidate>,
+): Promise<void> {
+  const xs = await gatherCandidates(denops, bufnr, range);
+  const x = xs.at(0);
+  if (!x) return;
+  const commit = x.commit;
+
+  const worktree = await findWorktreeFromDenops(denops);
+  const gitdir = await findGitdir(worktree);
+
+  // Clean up any leftover state from a previous split
+  await tryCleanupSplitTemplate(worktree);
+
+  // Guard: check if rebase is already in progress
+  if (await isRebaseInProgress(worktree)) {
+    await helper.echoerr(
+      denops,
+      "A rebase is already in progress. Complete or abort it first.",
+    );
+    return;
+  }
+
+  // Get original commit message and comment each line for reference
+  const origMsgRaw = decodeUtf8(
+    await execute(["log", "-1", "--format=%B", commit], { cwd: worktree }),
+  ).trimEnd();
+  const commentedOrigMsg = origMsgRaw
+    .split("\n")
+    .map((line) => `# ${line}`)
+    .join("\n");
+
+  // Build composite template: empty first line + user template + commented original message
+  const userTemplate = await getUserCommitTemplate(worktree);
+  const splitMsgContent = [
+    "",
+    ...(userTemplate ? [userTemplate.trimEnd(), ""] : []),
+    "# --- Original commit message (for reference) ---",
+    commentedOrigMsg,
+    "",
+  ].join("\n");
+  const splitMsgPath = path.join(gitdir, SPLIT_MSG_FILENAME);
+  await Deno.writeTextFile(splitMsgPath, splitMsgContent);
+
+  // Backup existing local commit.template before overriding
+  const origLocalTemplate = await getLocalCommitTemplate(worktree);
+  const backupPath = path.join(gitdir, BACKUP_FILENAME);
+  await Deno.writeTextFile(backupPath, origLocalTemplate ?? "");
+
+  // Set our split template as the local commit.template
+  await execute(
+    ["config", "--local", "commit.template", splitMsgPath],
+    { cwd: worktree },
+  );
+
+  // Run rebase with sequence editor that marks the target commit as "edit"
+  const seqEditorScript = path.fromFileUrl(
+    new URL("../proxy/sequence_editor.ts", import.meta.url),
+  );
+  const env = await fn.environ(denops) as Record<string, string>;
+  try {
+    await execute(
+      [
+        "-c",
+        `sequence.editor=${seqEditorScript}`,
+        "rebase",
+        "--interactive",
+        "--autostash",
+        "--keep-empty",
+        `${commit}^`,
+      ],
+      {
+        cwd: worktree,
+        env: { ...env, GIN_SPLIT_TARGET: commit },
+      },
+    );
+  } catch (e) {
+    // Rebase failed, restore commit.template immediately
+    await tryCleanupSplitTemplate(worktree);
+    await helper.echoerr(denops, `Rebase failed: ${e}`);
+    return;
+  }
+
+  // Decompose the commit: reset HEAD~ keeps changes in working tree
+  await execute(["reset", "HEAD~"], { cwd: worktree, env });
+
+  // Suppress false-positive detection of file changes
+  await denops.cmd("silent checktime");
+
+  // Open GinStatus for the user to stage and commit
+  await denops.dispatch("gin", "status:command", "", "", [
+    `++opener=${opener}`,
+  ]);
+}
+
+/**
+ * Get the effective commit.template content (from any config level).
+ */
+async function getUserCommitTemplate(
+  worktree: string,
+): Promise<string | undefined> {
+  let templatePath: string;
+  try {
+    templatePath = decodeUtf8(
+      await execute(["config", "--get", "commit.template"], { cwd: worktree }),
+    ).trim();
+  } catch {
+    return undefined;
+  }
+  if (!templatePath) return undefined;
+
+  // Resolve ~ and relative paths
+  const resolvedPath = templatePath.startsWith("~")
+    ? path.join(Deno.env.get("HOME") ?? "", templatePath.slice(1))
+    : path.isAbsolute(templatePath)
+    ? templatePath
+    : path.join(worktree, templatePath);
+
+  try {
+    return await Deno.readTextFile(resolvedPath);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Get the local (repo-level) commit.template value.
+ */
+async function getLocalCommitTemplate(
+  worktree: string,
+): Promise<string | undefined> {
+  try {
+    const value = decodeUtf8(
+      await execute(
+        ["config", "--local", "--get", "commit.template"],
+        { cwd: worktree },
+      ),
+    ).trim();
+    return value || undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/denops/gin/command/bare/command.ts
+++ b/denops/gin/command/bare/command.ts
@@ -35,6 +35,8 @@ export async function exec(
     denops,
     removeAnsiEscapeCode(content.join("\n")),
   );
+  // Reload files that may have been changed by the git command
+  await denops.cmd("silent checktime");
   if (!eventignore.includes("all")) {
     await denops.call(
       "gin#internal#util#debounce",

--- a/denops/gin/command/log/edit.ts
+++ b/denops/gin/command/log/edit.ts
@@ -28,6 +28,7 @@ import { init as initActionRevert } from "../../action/revert.ts";
 import { init as initActionShow } from "../../action/show.ts";
 import { init as initActionSwitch } from "../../action/switch.ts";
 import { init as initActionTag } from "../../action/tag.ts";
+import { init as initActionCommitSplit } from "../../action/commit_split.ts";
 import { init as initActionYank } from "../../action/yank.ts";
 import { Entry, parse as parseLog } from "./parser.ts";
 
@@ -98,6 +99,14 @@ export async function exec(
       await initActionBrowse(denops, bufnr, gatherCandidates);
       await initActionCherryPick(denops, bufnr, gatherCandidates);
       await initActionEcho(denops, bufnr, gatherCandidates);
+      await initActionCommitSplit(
+        denops,
+        bufnr,
+        async (denops, bufnr, range) => {
+          const xs = await gatherCandidates(denops, bufnr, range);
+          return xs.map((x) => ({ commit: x.commit }));
+        },
+      );
       await initActionFixup(denops, bufnr, async (denops, bufnr, range) => {
         const xs = await gatherCandidates(denops, bufnr, range);
         return xs.map((x) => ({ commit: x.commit }));

--- a/denops/gin/command/reflog/edit.ts
+++ b/denops/gin/command/reflog/edit.ts
@@ -28,6 +28,7 @@ import { init as initActionRevert } from "../../action/revert.ts";
 import { init as initActionShow } from "../../action/show.ts";
 import { init as initActionSwitch } from "../../action/switch.ts";
 import { init as initActionTag } from "../../action/tag.ts";
+import { init as initActionCommitSplit } from "../../action/commit_split.ts";
 import { init as initActionYank } from "../../action/yank.ts";
 import { Entry, parse as parseReflog } from "./parser.ts";
 
@@ -94,6 +95,14 @@ export async function exec(
       await initActionBrowse(denops, bufnr, gatherCandidates);
       await initActionCherryPick(denops, bufnr, gatherCandidates);
       await initActionEcho(denops, bufnr, gatherCandidates);
+      await initActionCommitSplit(
+        denops,
+        bufnr,
+        async (denops, bufnr, range) => {
+          const xs = await gatherCandidates(denops, bufnr, range);
+          return xs.map((x) => ({ commit: x.commit }));
+        },
+      );
       await initActionFixup(denops, bufnr, async (denops, bufnr, range) => {
         const xs = await gatherCandidates(denops, bufnr, range);
         return xs.map((x) => ({ commit: x.commit }));

--- a/denops/gin/command/status/edit.ts
+++ b/denops/gin/command/status/edit.ts
@@ -13,6 +13,7 @@ import { bind } from "../../command/bare/command.ts";
 import { exec as execBuffer } from "../../command/buffer/edit.ts";
 import { findWorktreeFromDenops } from "../../git/worktree.ts";
 import { getRebaseState } from "../../git/rebase.ts";
+import { tryCleanupSplitTemplate } from "../../action/commit_split.ts";
 import { init as initActionAdd } from "../../action/add.ts";
 import { init as initActionBrowse } from "../../action/browse.ts";
 import { init as initActionChaperon } from "../../action/chaperon.ts";
@@ -91,6 +92,8 @@ export async function exec(
       }
       await fn.winrestview(denops, saved);
     });
+    // Clean up commit.template override if rebase has completed
+    await tryCleanupSplitTemplate(worktree);
     await batch.batch(denops, async (denops) => {
       await bind(denops, bufnr);
       await initActionCore(denops, bufnr);

--- a/denops/gin/command/status/edit.ts
+++ b/denops/gin/command/status/edit.ts
@@ -12,6 +12,7 @@ import { Flags, formatFlags, parseOpts } from "jsr:@denops/std@^7.0.0/argument";
 import { bind } from "../../command/bare/command.ts";
 import { exec as execBuffer } from "../../command/buffer/edit.ts";
 import { findWorktreeFromDenops } from "../../git/worktree.ts";
+import { getRebaseState } from "../../git/rebase.ts";
 import { init as initActionAdd } from "../../action/add.ts";
 import { init as initActionBrowse } from "../../action/browse.ts";
 import { init as initActionChaperon } from "../../action/chaperon.ts";
@@ -74,9 +75,20 @@ export async function exec(
     fileformat: options.fileformat,
   });
   await buffer.ensure(denops, bufnr, async () => {
+    const worktree = await findWorktreeFromDenops(denops);
     await buffer.modifiable(denops, bufnr, async () => {
       const saved = await fn.winsaveview(denops);
       await denops.cmd("silent! 2,$sort /.. /)");
+      // Inject rebase state as a header line (parser skips ## lines)
+      const rebaseState = await getRebaseState(worktree);
+      if (rebaseState) {
+        const prefix = rebaseState.interactive ? "REBASE-i" : "REBASE";
+        await fn.append(
+          denops,
+          1,
+          `## ${prefix} ${rebaseState.current}/${rebaseState.total} on ${rebaseState.headName}`,
+        );
+      }
       await fn.winrestview(denops, saved);
     });
     await batch.batch(denops, async (denops) => {

--- a/denops/gin/component/rebase.ts
+++ b/denops/gin/component/rebase.ts
@@ -1,0 +1,38 @@
+import type { Denops } from "jsr:@denops/std@^7.0.0";
+import { Cache } from "jsr:@lambdalisue/ttl-cache@^1.0.0";
+import { findWorktreeFromDenops } from "../git/worktree.ts";
+import { getRebaseState, RebaseState } from "../git/rebase.ts";
+
+const cache = new Cache<string, RebaseState | undefined>(100);
+
+async function getData(
+  denops: Denops,
+): Promise<RebaseState | undefined> {
+  return cache.get("data") ?? await (async () => {
+    const worktree = await findWorktreeFromDenops(denops);
+    const result = await getRebaseState(worktree);
+    cache.set("data", result);
+    return result;
+  })();
+}
+
+function formatRebaseState(state: RebaseState): string {
+  const prefix = state.interactive ? "REBASE-i" : "REBASE";
+  return `${prefix} ${state.current}/${state.total}`;
+}
+
+export function main(denops: Denops): void {
+  denops.dispatcher = {
+    ...denops.dispatcher,
+    "component:rebase:ascii": async () => {
+      const state = await getData(denops);
+      if (!state) return "";
+      return formatRebaseState(state);
+    },
+    "component:rebase:unicode": async () => {
+      const state = await getData(denops);
+      if (!state) return "";
+      return formatRebaseState(state);
+    },
+  };
+}

--- a/denops/gin/git/rebase.ts
+++ b/denops/gin/git/rebase.ts
@@ -1,0 +1,103 @@
+import * as path from "jsr:@std/path@^1.0.0";
+import { findGitdir } from "./finder.ts";
+
+export type RebaseState = {
+  /** "merge" for rebase -i / rebase --merge, "apply" for rebase --apply */
+  type: "merge" | "apply";
+  /** Current step number (1-based) */
+  current: number;
+  /** Total number of steps */
+  total: number;
+  /** Original branch name (e.g. "main", not "refs/heads/main") */
+  headName: string;
+  /** Whether this is an interactive rebase */
+  interactive: boolean;
+};
+
+/**
+ * Get the current rebase state by inspecting .git/rebase-merge/ or .git/rebase-apply/.
+ * Returns undefined if no rebase is in progress.
+ */
+export async function getRebaseState(
+  worktree: string,
+): Promise<RebaseState | undefined> {
+  const gitdir = await findGitdir(worktree);
+
+  // Check rebase-merge (interactive rebase, rebase --merge)
+  const rebaseMergeDir = path.join(gitdir, "rebase-merge");
+  if (await exists(rebaseMergeDir)) {
+    return await readRebaseMergeState(rebaseMergeDir);
+  }
+
+  // Check rebase-apply (non-interactive rebase, git am)
+  const rebaseApplyDir = path.join(gitdir, "rebase-apply");
+  if (await exists(rebaseApplyDir)) {
+    return await readRebaseApplyState(rebaseApplyDir);
+  }
+
+  return undefined;
+}
+
+/**
+ * Check if a rebase is in progress by inspecting the git directory.
+ */
+export async function isRebaseInProgress(
+  worktree: string,
+): Promise<boolean> {
+  const gitdir = await findGitdir(worktree);
+  return await exists(path.join(gitdir, "rebase-merge")) ||
+    await exists(path.join(gitdir, "rebase-apply"));
+}
+
+async function readRebaseMergeState(dir: string): Promise<RebaseState> {
+  const [msgnum, end, headName, interactive] = await Promise.all([
+    readFileAsNumber(path.join(dir, "msgnum")),
+    readFileAsNumber(path.join(dir, "end")),
+    readFileAsString(path.join(dir, "head-name")),
+    exists(path.join(dir, "interactive")),
+  ]);
+  return {
+    type: "merge",
+    current: msgnum,
+    total: end,
+    headName: headName.replace(/^refs\/heads\//, ""),
+    interactive,
+  };
+}
+
+async function readRebaseApplyState(dir: string): Promise<RebaseState> {
+  const [next, last, headName] = await Promise.all([
+    readFileAsNumber(path.join(dir, "next")),
+    readFileAsNumber(path.join(dir, "last")),
+    readFileAsString(path.join(dir, "head-name")),
+  ]);
+  return {
+    type: "apply",
+    current: next,
+    total: last,
+    headName: headName.replace(/^refs\/heads\//, ""),
+    interactive: false,
+  };
+}
+
+async function exists(filepath: string): Promise<boolean> {
+  try {
+    await Deno.stat(filepath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readFileAsString(filepath: string): Promise<string> {
+  try {
+    return (await Deno.readTextFile(filepath)).trim();
+  } catch {
+    return "";
+  }
+}
+
+async function readFileAsNumber(filepath: string): Promise<number> {
+  const s = await readFileAsString(filepath);
+  return Number(s) || 0;
+}

--- a/denops/gin/main.ts
+++ b/denops/gin/main.ts
@@ -19,6 +19,7 @@ import { main as mainStatus } from "./command/status/main.ts";
 import { main as mainTag } from "./command/tag/main.ts";
 
 import { main as mainComponentBranch } from "./component/branch.ts";
+import { main as mainComponentRebase } from "./component/rebase.ts";
 import { main as mainComponentTraffic } from "./component/traffic.ts";
 import { main as mainComponentWorktree } from "./component/worktree.ts";
 
@@ -42,6 +43,7 @@ export function main(denops: Denops): void {
   mainTag(denops);
 
   mainComponentBranch(denops);
+  mainComponentRebase(denops);
   mainComponentTraffic(denops);
   mainComponentWorktree(denops);
 }

--- a/denops/gin/main.ts
+++ b/denops/gin/main.ts
@@ -23,6 +23,9 @@ import { main as mainComponentRebase } from "./component/rebase.ts";
 import { main as mainComponentTraffic } from "./component/traffic.ts";
 import { main as mainComponentWorktree } from "./component/worktree.ts";
 
+import { tryCleanupSplitTemplate } from "./action/commit_split.ts";
+import { findWorktreeFromDenops } from "./git/worktree.ts";
+
 export function main(denops: Denops): void {
   mainBare(denops);
   mainBuffer(denops);
@@ -46,4 +49,17 @@ export function main(denops: Denops): void {
   mainComponentRebase(denops);
   mainComponentTraffic(denops);
   mainComponentWorktree(denops);
+
+  // Static dispatcher for commit:split cleanup (called on plugin load)
+  denops.dispatcher = {
+    ...denops.dispatcher,
+    "commit_split:try_cleanup": async () => {
+      try {
+        const worktree = await findWorktreeFromDenops(denops);
+        await tryCleanupSplitTemplate(worktree);
+      } catch {
+        // Not in a git worktree, ignore
+      }
+    },
+  };
 }

--- a/denops/gin/proxy/sequence_editor.ts
+++ b/denops/gin/proxy/sequence_editor.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env -S deno run --no-check --allow-env=GIN_SPLIT_TARGET --allow-read --allow-write
+// Rewrite `pick <hash>` to `edit <hash>` in the rebase todo file.
+// Used by the commit:split action to mark a specific commit for editing.
+
+const target = Deno.env.get("GIN_SPLIT_TARGET");
+if (!target) {
+  console.error("GIN_SPLIT_TARGET environment variable is required");
+  Deno.exit(1);
+}
+
+const todoFile = Deno.args[0];
+if (!todoFile) {
+  console.error("No filename specified");
+  Deno.exit(1);
+}
+
+let content = await Deno.readTextFile(todoFile);
+
+// Match short hash at the beginning of a pick line
+const shortHash = target.substring(0, 7);
+const pattern = new RegExp(`^pick (${shortHash}\\S*)`, "m");
+if (!pattern.test(content)) {
+  console.error(`Could not find commit ${shortHash} in rebase todo`);
+  Deno.exit(1);
+}
+
+content = content.replace(pattern, "edit $1");
+await Deno.writeTextFile(todoFile, content);

--- a/doc/gin.txt
+++ b/doc/gin.txt
@@ -497,6 +497,11 @@ COMMANDS					*gin-commands*
 :GinStatus[!] [{++option}...] [{flags}] [-- {pathspec}...]
 	Open a "gin-status" buffer to show a status.
 
+	When a rebase is in progress (either interactive or non-interactive),
+	a rebase progress header is automatically displayed at the top of the
+	buffer showing the current commit being processed and the total number
+	of commits (e.g., "REBASE 3/10" or "REBASE-i 3/10").
+
 	See |gin-commands-options| for common {++option}.
 
 	The following flags are valid as {flags}:
@@ -973,6 +978,15 @@ gin#component#branch#unicode()
 gin#component#traffic#ascii()
 gin#component#traffic#unicode()
 	Return an indicator string of the number of ahead and behind commits.
+
+					*gin#component#rebase#ascii()*
+					*gin#component#rebase#unicode()*
+gin#component#rebase#ascii()
+gin#component#rebase#unicode()
+	Return an indicator string of the rebase progress when a rebase is
+	in progress. Returns empty string when no rebase is in progress.
+	The format is "REBASE N/M" or "REBASE-i N/M" where N is the current
+	commit being processed and M is the total number of commits.
 
 					*gin#component#worktree#name()*
 					*gin#component#worktree#full()*

--- a/doc/gin.txt
+++ b/doc/gin.txt
@@ -1029,6 +1029,23 @@ NOTE that we won't list all actions available here because there are too many
 of them and we cannot maintain correct documentation of that.
 Use the "help" action to check what actions are available on each gin buffer.
 
+							*gin-action-commit:split*
+commit:split
+commit:split:{opener}
+	Split a commit into multiple commits via interactive rebase. This
+	action is available in |:GinLog|, |:GinReflog|, and |:GinStatus|
+	buffers. When invoked on a commit, it:
+
+	1. Starts an interactive rebase at the target commit
+	2. Resets the commit (keeping changes in working tree)
+	3. Opens |:GinStatus| to let you stage and commit changes
+
+	After completing your new commits, continue the rebase with
+	"git rebase --continue" (or use the continue:rebase action).
+
+	Available openers: edit, split, vsplit, tabedit
+	The default opener is "edit".
+
 *<Plug>(gin-action-echo)*
 	Echo active action candidates for debugging.
 

--- a/doc/gin.txt
+++ b/doc/gin.txt
@@ -506,7 +506,7 @@ COMMANDS					*gin-commands*
 	--ignored[=traditional/no/matching]
 	--renames/--no-renames
 	--find-renames[={n}]
-		
+
 	See ":man git-status(1)" for detail about each {flags}.
 
 	Several default mappings are defined in the buffer. Use "help" action
@@ -861,6 +861,21 @@ VARIABLES					*gin-variables*
 
 *g:gin_stash_disable_default_mappings*
 	Disable default mappings on buffers shown by |:GinStash|.
+
+	Default: 0
+
+*g:gin_tag_default_args*
+	Specify default arguments of |:GinTag|.
+
+	Default: []
+
+*g:gin_tag_persistent_args*
+	Specify persistent arguments of |:GinTag|.
+
+	Default: []
+
+*g:gin_tag_disable_default_mappings*
+	Disable default mappings on buffers shown by |:GinTag|.
 
 	Default: 0
 

--- a/plugin/gin.vim
+++ b/plugin/gin.vim
@@ -11,6 +11,8 @@ augroup gin_plugin_internal
         \ call denops#request('gin', 'buffer:edit', [bufnr(), expand('<amatch>')])
   autocmd FileReadCmd gin://*
         \ call denops#request('gin', 'buffer:read', [bufnr(), expand('<amatch>')])
+  autocmd User DenopsPluginPost:gin
+        \ call denops#notify('gin', 'commit_split:try_cleanup', [])
 augroup END
 
 function! s:command(bang, mods, args) abort


### PR DESCRIPTION
## Summary
- Add `commit:split` action to interactively split commits via rebase in GinLog, GinReflog, and GinStatus buffers
- Add rebase progress component and status header to show rebase state (e.g., "REBASE-i 3/10") in statusline and GinStatus buffer
- Fix buffer reload issue after bare git commands to reflect external changes

## Why

Git's commit splitting workflow requires manually running several commands: starting an interactive rebase, marking a commit for editing, resetting it, staging changes incrementally, and continuing the rebase. This is tedious and error-prone for users who want to decompose a large commit into smaller, focused commits.

This PR streamlines the workflow with a single `commit:split` action that:
1. Automatically starts an interactive rebase on the target commit
2. Resets the commit while preserving changes in the working tree
3. Opens GinStatus so users can immediately stage and commit changes
4. Preserves user's commit.template across rebase sessions with automatic cleanup

The rebase progress indicator addresses the lack of visual feedback during rebase operations. Users can now see at a glance where they are in a rebase sequence both in the statusline (via component) and in the GinStatus buffer header.

The buffer reload fix ensures that when users run bare git commands via `:Gin` that modify files, those changes are immediately reflected in open buffers instead of requiring manual `:checktime`.

## Test plan
- [ ] Test `commit:split` action in GinLog buffer on a commit with multiple changes
- [ ] Test `commit:split` action in GinReflog buffer
- [ ] Test `commit:split` action in GinStatus buffer (when available)
- [ ] Verify GinStatus opens after split and shows uncommitted changes
- [ ] Create multiple new commits and run `git rebase --continue` to verify workflow
- [ ] Verify commit.template is preserved (check with `git config commit.template` before/after)
- [ ] Verify cleanup occurs automatically after rebase completes
- [ ] Test rebase progress indicator in statusline with `gin#component#rebase#ascii()`
- [ ] Test rebase progress header appears in GinStatus during rebase
- [ ] Test with both interactive rebase (`rebase -i`) and non-interactive rebase
- [ ] Verify error handling when rebase is already in progress
- [ ] Test `commit:split:split`, `commit:split:vsplit`, `commit:split:tabedit` openers
- [ ] Run `:Gin commit --amend` and verify buffer reloads automatically show the change